### PR TITLE
fix: align YOLOv5 OSD coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ flowchart LR
 - AI VPSS 通道号、宽高、FPS、NV12、depth/buffer 和 fit mode 全部由激活项目 manifest 注入，已验证 `640×360/stretch` 与 `640×640/contain` 在线切换。
 - Lua 项目 CRUD、语法/manifest 校验、不可变候选部署、首次推理验收和 last-good 自动回滚；模型支持原子上传和活动引用保护。
 - VisionG v1.2.1 + YOLOv5n COCO80 RKNN 已在 RV1106 真机持续运行，640×640 推理约 75 ms、结果约 10 FPS。
-- OSD 三态：`off`、默认 `metadata`、`embedded_rgn`。metadata 通过 WebRTC DataChannel/SSE 平滑叠加；embedded 在 RV1106 使用 `COVER_RGN@VI`，可进入 WebRTC、RTSP 和 MP4，且不使用同步 RGA 合成。
+- VisionG 的 `(x, y, width, height)` 检测结果会转换为统一角点坐标，再依据 stretch/contain/cover 变换映射到主路归一化坐标，避免模型输入、letterbox 与输出画面尺寸不同造成框偏移。
+- OSD 三态：`off`、默认 `metadata`、`embedded_rgn`。metadata 通过 WebRTC DataChannel/SSE 平滑叠加；embedded 在 RV1106 使用 `COVER_RGN@VI`，运行时探测 VI 原始坐标尺寸并从主路坐标域缩放，可进入 WebRTC、RTSP 和 MP4，且不使用同步 RGA 合成。
 - ADB + 以太网/Wi-Fi 联合部署验证流程；已验证 HTTP、WebRTC、MP4/Range、ZIP、RTSP TCP/UDP、AI 崩溃恢复和 10 分钟持续运行。
 
 ## 功能实现矩阵
@@ -88,7 +89,7 @@ flowchart LR
 | RKNN 视觉模型推理 | 🧪 | ✅ | 🚧 | 🚧 | VisionG v1.2.1、YOLOv5、动态 640×360/640×640 AI VPSS |
 | AI worker 故障隔离 | 🧪 | ✅ | 🚧 | 🚧 | AI 独立重启，主 VPSS/VENC generation 保持不变 |
 | 浏览器 metadata OSD | 🧪 | ✅ | 🚧 | 🚧 | WebRTC DataChannel + SSE fallback、归一化坐标、插值/外推和过期淡出 |
-| 编码流硬件 RGN OSD | 🧪 | ✅ | 🚧 | 🚧 | RV1106 使用 COVER_RGN@VI；RTSP、WebRTC 和 MP4 均可带框 |
+| 编码流硬件 RGN OSD | 🧪 | ✅ | 🚧 | 🚧 | RV1106 使用 COVER_RGN@VI，动态探测并映射 VI 坐标域；RTSP、WebRTC 和 MP4 均可带框 |
 | RK3576 适配 | ⬜ | — | 🚧 | — | 待建立统一 SoC 媒体能力和构建抽象 |
 | RV1126B 适配 | ⬜ | — | — | 🚧 | 待验证 SDK、ISP、编码器和板端部署差异 |
 
@@ -183,7 +184,13 @@ daemon 当前未启用身份认证，只应暴露在可信局域网中。
 项目 manifest 是 AI 输入参数的唯一权威来源。切换输入尺寸时只在线重配 AI VPSS
 通道；失败会恢复 last-good 项目，不会重启主 VPSS、VENC 或 media worker。metadata
 只影响浏览器叠加，RTSP/MP4 保持原始画面；embedded 是全局硬件叠加，所有编码输出
-都会带矩形框。接口和协议细节见
+都会带矩形框。
+
+检测结果在进程间统一使用主路归一化坐标。AI worker 会将 VisionG 返回的 `xywh`
+转换为角点并反解模型输入的缩放、裁剪或 letterbox；media worker 则在启用硬件 RGN
+时查询 VI 的实际坐标尺寸（RV1106 实测为传感器原始坐标域），再按归一化边界完成
+缩放。这样浏览器 metadata、WebRTC、RTSP 和录像中的 embedded 框使用同一目标位置，
+且坐标转换不会进入 VENC 的同步关键路径。接口和协议细节见
 [`docs/ai_worker_lua_architecture.md`](./docs/ai_worker_lua_architecture.md)。
 
 ## 路线图

--- a/ai_worker/CMakeLists.txt
+++ b/ai_worker/CMakeLists.txt
@@ -39,6 +39,21 @@ install(FILES
 
 if(AIPC_NATIVE_BUILD_TESTS)
     enable_testing()
+    add_executable(ai_worker_backend_tests
+        tests/backend_test.cpp
+        src/backend.cpp
+    )
+    target_include_directories(ai_worker_backend_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src)
+    target_link_libraries(ai_worker_backend_tests PRIVATE
+        Aipc::NativeOptions
+        Aipc::NativeCommon
+        nlohmann_json::nlohmann_json
+    )
+    target_compile_definitions(ai_worker_backend_tests PRIVATE
+        AIPC_ENABLE_VISIONG=0)
+    add_test(NAME ai_worker_backend_tests COMMAND ai_worker_backend_tests)
+
     add_test(
         NAME ai_worker_lua_validation
         COMMAND ai_worker

--- a/ai_worker/src/backend.cpp
+++ b/ai_worker/src/backend.cpp
@@ -1,7 +1,9 @@
 #include "backend.h"
 
 #include <algorithm>
+#include <limits>
 #include <stdexcept>
+#include <utility>
 
 #if AIPC_ENABLE_VISIONG
 #include <visiong/core/ImageBuffer.h>
@@ -10,6 +12,13 @@
 
 namespace ai_worker {
 namespace {
+
+int SaturatingAdd(int value, int delta) {
+    const auto result = static_cast<long long>(value) +
+                        static_cast<long long>(std::max(0, delta));
+    return static_cast<int>(std::min(
+        result, static_cast<long long>(std::numeric_limits<int>::max())));
+}
 
 class MockBackend final : public Backend {
 public:
@@ -44,9 +53,12 @@ public:
         std::vector<DetectionResult> output;
         output.reserve(detections.size());
         for (const auto& detection : detections) {
-            const auto [x1, y1, x2, y2] = detection.box;
-            output.push_back({x1, y1, x2, y2, detection.score,
-                              detection.class_id, detection.label});
+            // VisionG exposes Detection.box as (x, y, width, height), while
+            // AIPR deliberately uses explicit corner coordinates.
+            const auto [x, y, width, height] = detection.box;
+            output.push_back(DetectionFromXywh(
+                x, y, width, height, detection.score, detection.class_id,
+                detection.label));
         }
         return output;
     }
@@ -59,6 +71,13 @@ private:
 #endif
 
 }  // namespace
+
+DetectionResult DetectionFromXywh(int x, int y, int width, int height,
+                                  float score, int class_id,
+                                  std::string label) {
+    return {x, y, SaturatingAdd(x, width), SaturatingAdd(y, height),
+            score, class_id, std::move(label)};
+}
 
 std::unique_ptr<Backend> CreateMockBackend() {
     return std::make_unique<MockBackend>();

--- a/ai_worker/src/backend.h
+++ b/ai_worker/src/backend.h
@@ -14,6 +14,10 @@ public:
     virtual const char* Name() const = 0;
 };
 
+DetectionResult DetectionFromXywh(int x, int y, int width, int height,
+                                  float score, int class_id,
+                                  std::string label);
+
 std::unique_ptr<Backend> CreateMockBackend();
 std::unique_ptr<Backend> CreateBackend(const Options& options,
                                        const Manifest& manifest);

--- a/ai_worker/tests/backend_test.cpp
+++ b/ai_worker/tests/backend_test.cpp
@@ -1,0 +1,33 @@
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "backend.h"
+
+namespace {
+
+void Expect(bool condition, const char* message) {
+    if (condition) return;
+    std::cerr << "FAILED: " << message << '\n';
+    std::exit(1);
+}
+
+}  // namespace
+
+int main() {
+    const auto detection = ai_worker::DetectionFromXywh(
+        98, 140, 280, 246, 0.75F, 62, "tv");
+    Expect(detection.x1 == 98, "x origin is preserved");
+    Expect(detection.y1 == 140, "y origin is preserved");
+    Expect(detection.x2 == 378, "VisionG width becomes the right edge");
+    Expect(detection.y2 == 386, "VisionG height becomes the bottom edge");
+    Expect(detection.score == 0.75F, "score is preserved");
+    Expect(detection.class_id == 62, "class id is preserved");
+    Expect(detection.label == "tv", "label is preserved");
+
+    const auto invalid_size = ai_worker::DetectionFromXywh(
+        10, 20, -1, -2, 0.5F, 0, "invalid");
+    Expect(invalid_size.x2 == 10, "negative width does not invert the box");
+    Expect(invalid_size.y2 == 20, "negative height does not invert the box");
+    return 0;
+}

--- a/media_worker/CMakeLists.txt
+++ b/media_worker/CMakeLists.txt
@@ -15,13 +15,15 @@ add_library(media_worker_audio_ipc STATIC src/audio_ipc_publisher.cpp)
 add_library(media_worker_ai_ipc STATIC src/ai_frame_ipc_publisher.cpp)
 add_library(media_worker_control STATIC src/media_control.cpp)
 add_library(media_worker_metrics STATIC src/metrics_sampler.cpp)
+add_library(media_worker_rgn_coordinates STATIC src/rgn_coordinates.cpp)
 
 foreach(target
         media_worker_video_ipc
         media_worker_audio_ipc
         media_worker_ai_ipc
         media_worker_control
-        media_worker_metrics)
+        media_worker_metrics
+        media_worker_rgn_coordinates)
     target_include_directories(${target} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
     target_link_libraries(${target} PUBLIC Aipc::NativeOptions Threads::Threads)
 endforeach()
@@ -53,6 +55,7 @@ if(AIPC_ENABLE_RV1106)
         media_worker_audio_ipc
         media_worker_ai_ipc
         media_worker_control
+        media_worker_rgn_coordinates
         Rockchip::MediaRuntime
         Threads::Threads
         dl
@@ -76,4 +79,5 @@ if(AIPC_NATIVE_BUILD_TESTS)
     aipc_media_test(media_worker_audio_ipc_tests tests/audio_ipc_publisher_test.cpp media_worker_audio_ipc)
     aipc_media_test(media_worker_metrics_tests tests/metrics_sampler_test.cpp media_worker_metrics)
     aipc_media_test(media_worker_ai_ipc_tests tests/ai_frame_ipc_publisher_test.cpp media_worker_ai_ipc)
+    aipc_media_test(media_worker_rgn_coordinates_tests tests/rgn_coordinates_test.cpp media_worker_rgn_coordinates)
 endif()

--- a/media_worker/src/rgn_coordinates.cpp
+++ b/media_worker/src/rgn_coordinates.cpp
@@ -1,0 +1,30 @@
+#include "rgn_coordinates.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace media_worker {
+namespace {
+
+int ScaleEdge(int value, int source_size, int target_size) {
+    if (source_size <= 0 || target_size <= 0) return value;
+    return static_cast<int>(std::llround(
+        static_cast<double>(value) * target_size / source_size));
+}
+
+}  // namespace
+
+OsdRegion ScaleOsdRegion(const OsdRegion& region, int source_width,
+                         int source_height, int target_width,
+                         int target_height) {
+    const int left = ScaleEdge(region.x, source_width, target_width);
+    const int top = ScaleEdge(region.y, source_height, target_height);
+    const int right = ScaleEdge(region.x + std::max(0, region.width),
+                                source_width, target_width);
+    const int bottom = ScaleEdge(region.y + std::max(0, region.height),
+                                 source_height, target_height);
+    return {left, top, std::max(0, right - left),
+            std::max(0, bottom - top)};
+}
+
+}  // namespace media_worker

--- a/media_worker/src/rgn_coordinates.h
+++ b/media_worker/src/rgn_coordinates.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace media_worker {
+
+struct OsdRegion {
+    int x = 0;
+    int y = 0;
+    int width = 0;
+    int height = 0;
+};
+
+OsdRegion ScaleOsdRegion(const OsdRegion& region, int source_width,
+                         int source_height, int target_width,
+                         int target_height);
+
+}  // namespace media_worker

--- a/media_worker/src/rgn_manager.cpp
+++ b/media_worker/src/rgn_manager.cpp
@@ -6,6 +6,7 @@
 
 #include "rk_defines.h"
 #include "rk_mpi_rgn.h"
+#include "rk_mpi_vi.h"
 
 namespace media_worker {
 namespace {
@@ -41,7 +42,9 @@ RgnManager::RgnManager(int venc_channel, int vpss_group, int vpss_channel,
       vpss_channel_(vpss_channel),
       vi_device_(vi_device),
       frame_width_(frame_width),
-      frame_height_(frame_height) {}
+      frame_height_(frame_height),
+      target_width_(frame_width),
+      target_height_(frame_height) {}
 
 RgnManager::~RgnManager() { Deinit(); }
 
@@ -52,6 +55,8 @@ nlohmann::json RgnManager::Probe(std::string* error) {
             {"cover", available && backend_ == Backend::kCover},
             {"backend", available ? BackendName() : "none"},
             {"target", available ? TargetName() : "none"},
+            {"coordinate_width", available ? target_width_ : 0},
+            {"coordinate_height", available ? target_height_ : 0},
             {"max_boxes", max_boxes_},
             {"implemented", available}};
 }
@@ -132,6 +137,23 @@ bool RgnManager::TryInitialize(Backend backend, AttachTarget target,
     backend_ = backend;
     target_ = target;
     channel_ = ChannelForTarget(target);
+    target_width_ = frame_width_;
+    target_height_ = frame_height_;
+    if (target == AttachTarget::kVi) {
+        VI_DEV_STATUS_S status{};
+        const RK_S32 result = RK_MPI_VI_QueryDevStatus(vi_device_, &status);
+        if (result != RK_SUCCESS || status.stSize.u32Width == 0 ||
+            status.stSize.u32Height == 0) {
+            backend_ = Backend::kNone;
+            target_ = AttachTarget::kNone;
+            *error = result == RK_SUCCESS
+                         ? "VI device reported an empty RGN coordinate size"
+                         : MpiError("RK_MPI_VI_QueryDevStatus", result);
+            return false;
+        }
+        target_width_ = static_cast<int>(status.stSize.u32Width);
+        target_height_ = static_cast<int>(status.stSize.u32Height);
+    }
     for (std::size_t index = 0; index < kRequestedBoxes * kEdgesPerBox; ++index) {
         const RGN_HANDLE handle = kFirstHandle + static_cast<RGN_HANDLE>(index);
         std::string create_error;
@@ -232,11 +254,15 @@ bool RgnManager::SetHandleLocked(std::size_t index, const OsdRegion& input,
     RGN_CHN_ATTR_S display{};
     display.bShow = show ? RK_TRUE : RK_FALSE;
     display.enType = backend_ == Backend::kLine ? LINE_RGN : COVER_RGN;
+    const OsdRegion scaled = ScaleOsdRegion(
+        input, frame_width_, frame_height_, target_width_, target_height_);
     const int minimum = backend_ == Backend::kCover ? kCoverThickness : 2;
-    const int x = ClampEven(input.x, 0, std::max(0, frame_width_ - minimum));
-    const int y = ClampEven(input.y, 0, std::max(0, frame_height_ - minimum));
-    const int right = ClampEven(input.x + input.width, x + minimum, frame_width_);
-    const int bottom = ClampEven(input.y + input.height, y + minimum, frame_height_);
+    const int x = ClampEven(scaled.x, 0, std::max(0, target_width_ - minimum));
+    const int y = ClampEven(scaled.y, 0, std::max(0, target_height_ - minimum));
+    const int right = ClampEven(scaled.x + scaled.width, x + minimum,
+                                target_width_);
+    const int bottom = ClampEven(scaled.y + scaled.height, y + minimum,
+                                 target_height_);
     if (backend_ == Backend::kLine) {
         auto& line = display.unChnAttr.stLineChn;
         line.u32Thick = kLineThickness;
@@ -249,10 +275,10 @@ bool RgnManager::SetHandleLocked(std::size_t index, const OsdRegion& input,
         auto& cover = display.unChnAttr.stCoverChn;
         const int width = std::max(
             kCoverThickness,
-            AlignDown(std::min(right - x, frame_width_ - x), kCoverThickness));
+            AlignDown(std::min(right - x, target_width_ - x), kCoverThickness));
         const int height = std::max(
             kCoverThickness,
-            AlignDown(std::min(bottom - y, frame_height_ - y), kCoverThickness));
+            AlignDown(std::min(bottom - y, target_height_ - y), kCoverThickness));
         cover.u32Color = kColor;
         cover.u32Layer = static_cast<RK_U32>(index);
         cover.enCoordinate = RGN_ABS_COOR;
@@ -332,6 +358,8 @@ void RgnManager::Deinit() {
     max_boxes_ = 0;
     backend_ = Backend::kNone;
     target_ = AttachTarget::kNone;
+    target_width_ = frame_width_;
+    target_height_ = frame_height_;
     initialized_ = false;
 }
 

--- a/media_worker/src/rgn_manager.h
+++ b/media_worker/src/rgn_manager.h
@@ -10,17 +10,12 @@
 
 #include <nlohmann/json.hpp>
 
+#include "rgn_coordinates.h"
+
 #include "rk_common.h"
 #include "rk_comm_rgn.h"
 
 namespace media_worker {
-
-struct OsdRegion {
-    int x = 0;
-    int y = 0;
-    int width = 0;
-    int height = 0;
-};
 
 class RgnManager {
 public:
@@ -56,6 +51,8 @@ private:
     int vi_device_;
     int frame_width_;
     int frame_height_;
+    int target_width_;
+    int target_height_;
     MPP_CHN_S channel_{};
     Backend backend_ = Backend::kNone;
     AttachTarget target_ = AttachTarget::kNone;

--- a/media_worker/tests/rgn_coordinates_test.cpp
+++ b/media_worker/tests/rgn_coordinates_test.cpp
@@ -1,0 +1,34 @@
+#include <cstdlib>
+#include <iostream>
+
+#include "rgn_coordinates.h"
+
+namespace {
+
+void Expect(bool condition, const char* message) {
+    if (condition) return;
+    std::cerr << "FAILED: " << message << '\n';
+    std::exit(1);
+}
+
+}  // namespace
+
+int main() {
+    const media_worker::OsdRegion main_region{1764, 81, 153, 399};
+    const auto vi_region = media_worker::ScaleOsdRegion(
+        main_region, 1920, 1080, 2304, 1296);
+    Expect(vi_region.x == 2117, "VI left edge uses sensor coordinates");
+    Expect(vi_region.y == 97, "VI top edge uses sensor coordinates");
+    Expect(vi_region.width == 183, "VI width preserves normalized extent");
+    Expect(vi_region.height == 479, "VI height preserves normalized extent");
+
+    const auto unchanged = media_worker::ScaleOsdRegion(
+        main_region, 1920, 1080, 1920, 1080);
+    Expect(unchanged.x == main_region.x, "same-size x remains unchanged");
+    Expect(unchanged.y == main_region.y, "same-size y remains unchanged");
+    Expect(unchanged.width == main_region.width,
+           "same-size width remains unchanged");
+    Expect(unchanged.height == main_region.height,
+           "same-size height remains unchanged");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- interpret VisionG detection boxes as `(x, y, width, height)` before emitting AIPR corner coordinates
- query the active VI coordinate size and scale main-stream regions before programming embedded RGN handles
- expose the probed RGN coordinate dimensions in capability responses
- document the model-to-main-stream and main-stream-to-VI coordinate mapping in README
- add host regression tests for both coordinate conversions

## Validation

- `cmake --build --preset HostDebug`
- `ctest --preset HostDebug --output-on-failure` (9/9 passed)
- RV1106 metadata OSD alignment verified with YOLOv5n COCO80
- RV1106 `COVER_RGN@VI` alignment verified at 2304x1296 VI coordinates
- RTSP and embedded-RGN MP4 recording verified at 1920x1080/30 FPS
