### PR TITLE
feat: expose and visualize standardized AI results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
  "str0m",
  "tempfile",
  "thiserror 2.0.19",
+ "time",
  "tokio",
  "tokio-util",
  "tower",

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ flowchart LR
 - VisionG v1.2.1 + YOLOv5n COCO80 RKNN 已在 RV1106 真机持续运行，640×640 推理约 75 ms、结果约 10 FPS。
 - VisionG 的 `(x, y, width, height)` 检测结果会转换为统一角点坐标，再依据 stretch/contain/cover 变换映射到主路归一化坐标，避免模型输入、letterbox 与输出画面尺寸不同造成框偏移。
 - OSD 三态：`off`、默认 `metadata`、`embedded_rgn`。metadata 通过 WebRTC DataChannel/SSE 平滑叠加；embedded 在 RV1106 使用 `COVER_RGN@VI`，运行时探测 VI 原始坐标尺寸并从主路坐标域缩放，可进入 WebRTC、RTSP 和 MP4，且不使用同步 RGA 合成。
+- Rust daemon 提供 CloudEvents 1.0 标准 AI 结果接口：latest JSON、可用 `Last-Event-ID` 有界补发的 SSE、JSON Schema，以及 entered/updated/exited 目标生命周期事件，供报警、记录和其他服务消费。
 - ADB + 以太网/Wi-Fi 联合部署验证流程；已验证 HTTP、WebRTC、MP4/Range、ZIP、RTSP TCP/UDP、AI 崩溃恢复和 10 分钟持续运行。
 
 ## 功能实现矩阵
@@ -192,6 +193,25 @@ daemon 当前未启用身份认证，只应暴露在可信局域网中。
 缩放。这样浏览器 metadata、WebRTC、RTSP 和录像中的 embedded 框使用同一目标位置，
 且坐标转换不会进入 VENC 的同步关键路径。接口和协议细节见
 [`docs/ai_worker_lua_architecture.md`](./docs/ai_worker_lua_architecture.md)。
+
+### 外部进程消费 AI 结果
+
+新服务应使用标准化结果接口，而不是直接依赖浏览器 OSD 的兼容事件：
+
+```bash
+curl -fsS http://<board-ip>:8080/api/v1/ai/results/latest | jq
+curl -N http://<board-ip>:8080/api/v1/ai/results/stream
+curl -fsS http://<board-ip>:8080/api/v1/ai/results/schema | jq
+```
+
+结果使用 CloudEvents 1.0 structured JSON，检测框统一为主路左上角原点的 `[0,1]`
+归一化坐标，并携带 media/AI generation、单调微秒 PTS、项目、模型和推理耗时。
+SSE 支持 `Last-Event-ID` 重连补发；报警服务可直接消费 track entered/exited，记录
+服务可用 `media_generation + pts_us` 和录像关联。完整契约及 Python 示例见
+[`docs/ai_result_api.md`](./docs/ai_result_api.md)。
+
+Web 控制台的“AI 与 Lua”页面内置标准事件查看器，可实时筛选逐帧结果、目标生命周期、
+generation 和 replay gap，并展开查看完整 CloudEvent JSON 与结果总线状态。
 
 ## 路线图
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ AIPC_SKIP_BUILD=1 ./scripts/deploy-rv1106-adb.sh
 
 daemon 当前未启用身份认证，只应暴露在可信局域网中。
 
+Web 控制台的平台名称、板卡名称、控制台标题和项目链接来自 daemon 配置的 `ui`
+段，而不是写死在前端。适配新平台时可修改部署目录中的 `config/aipc-daemon.json`，字段
+示例见 [`config/aipc-daemon.example.json`](./config/aipc-daemon.example.json)。“关于”页面
+会同步展示这些平台信息、三进程架构、当前能力和项目链接。
+
 ## AI、Lua 与 OSD 快速使用
 
 完整包第一次启动时会将 `yolov5-coco80` 示例项目、YOLOv5n RKNN 模型和 COCO80

--- a/aipc-daemon/Cargo.toml
+++ b/aipc-daemon/Cargo.toml
@@ -26,6 +26,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 uuid = { version = "1", features = ["serde", "v4"] }
 str0m = { version = "=0.21.0", default-features = false, features = ["openssl"] }
+time = { version = "0.3.41", features = ["formatting"] }
 
 [build-dependencies]
 cc = "1"

--- a/aipc-daemon/src/ai_manager.rs
+++ b/aipc-daemon/src/ai_manager.rs
@@ -1,4 +1,9 @@
 use crate::ai::{AiFrame, AiHub, encode_ai_frame};
+use crate::ai_results::{
+    AiBoundingBoxV1, AiFrameInfoV1, AiGenerationEventDataV1, AiInferenceInfoV1, AiLifecycleTracker,
+    AiObjectV1, AiResultBus, AiResultBusStatus, AiResultInput, AiTrackEventDataV1,
+    FRAME_RESULT_TYPE, GENERATION_TYPE, TRACK_ENTERED_TYPE, TRACK_EXITED_TYPE, TRACK_UPDATED_TYPE,
+};
 use crate::config::{AiDaemonConfig, AiInputConfig};
 use crate::model::{ServerEvent, now_ms};
 use nix::sys::signal::{Signal, kill};
@@ -12,7 +17,7 @@ use std::os::unix::net::UnixStream as StdUnixStream;
 use std::os::unix::process::ExitStatusExt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex as StdMutex, RwLock};
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::Command;
@@ -168,6 +173,7 @@ pub struct AiStatus {
     pub last_error: Option<String>,
     pub osd_mode: OsdMode,
     pub rgn_capability: Option<Value>,
+    pub result_bus: AiResultBusStatus,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -182,6 +188,13 @@ struct PersistedAiState {
 struct Runtime {
     pid: u32,
     generation: String,
+}
+
+#[derive(Clone)]
+struct InferenceDescriptor {
+    project: String,
+    algorithm: String,
+    model: String,
 }
 
 #[derive(Clone)]
@@ -213,6 +226,9 @@ struct Inner {
     last_metadata: RwLock<Option<Arc<AiMetadata>>>,
     metadata_history: RwLock<VecDeque<TimedMetadata>>,
     tracker: Mutex<Tracker>,
+    result_bus: AiResultBus,
+    lifecycle: StdMutex<AiLifecycleTracker>,
+    active_inference: RwLock<Option<InferenceDescriptor>>,
     last_media_generation: Mutex<Option<String>>,
     recovery_times: Mutex<VecDeque<u64>>,
     recovery_tx: mpsc::Sender<(String, String)>,
@@ -250,6 +266,13 @@ impl AiManager {
         };
         let (metadata, _) = broadcast::channel(32);
         let (recovery_tx, recovery_rx) = mpsc::channel(4);
+        let result_bus = AiResultBus::new(config.source_id.clone(), config.result_replay_capacity);
+        let lifecycle = AiLifecycleTracker::new(
+            config.track_confirmations,
+            config.track_lost_timeout_ms,
+            config.track_update_interval_ms,
+        );
+        let tracker_retention_us = config.track_lost_timeout_ms.saturating_mul(1_000);
         let status = AiStatus {
             enabled: config.enabled,
             state: AiProcessState::Stopped,
@@ -267,6 +290,7 @@ impl AiManager {
             last_error: None,
             osd_mode: state.osd_mode,
             rgn_capability: None,
+            result_bus: result_bus.status(),
         };
         let manager = Self {
             inner: Arc::new(Inner {
@@ -284,7 +308,10 @@ impl AiManager {
                 metadata,
                 last_metadata: RwLock::new(None),
                 metadata_history: RwLock::new(VecDeque::with_capacity(2)),
-                tracker: Mutex::new(Tracker::default()),
+                tracker: Mutex::new(Tracker::new(tracker_retention_us)),
+                result_bus,
+                lifecycle: StdMutex::new(lifecycle),
+                active_inference: RwLock::new(None),
                 last_media_generation: Mutex::new(None),
                 recovery_times: Mutex::new(VecDeque::new()),
                 recovery_tx,
@@ -294,6 +321,7 @@ impl AiManager {
         manager.spawn_recovery_loop(recovery_rx);
         manager.spawn_media_reconcile_loop();
         manager.spawn_embedded_osd_loop();
+        manager.spawn_result_lifecycle_loop();
         Ok(manager)
     }
 
@@ -342,6 +370,7 @@ impl AiManager {
     pub fn status(&self) -> AiStatus {
         let mut status = self.inner.status.read().unwrap().clone();
         status.input = self.inner.hub.status();
+        status.result_bus = self.inner.result_bus.status();
         status
     }
 
@@ -358,6 +387,32 @@ impl AiManager {
 
     pub fn subscribe_metadata(&self) -> broadcast::Receiver<Arc<AiMetadata>> {
         self.inner.metadata.subscribe()
+    }
+
+    pub fn latest_result(&self) -> Option<Arc<crate::ai_results::AiCloudEvent>> {
+        self.inner.result_bus.latest()
+    }
+
+    pub fn subscribe_results(
+        &self,
+        cursor: Option<&str>,
+    ) -> crate::ai_results::AiResultSubscription {
+        self.inner.result_bus.subscribe_from(cursor)
+    }
+
+    pub fn replay_results_after(
+        &self,
+        sequence: u64,
+    ) -> (VecDeque<Arc<crate::ai_results::AiCloudEvent>>, u64) {
+        self.inner.result_bus.replay_after_sequence(sequence)
+    }
+
+    pub fn record_result_lag(&self, skipped: u64) {
+        self.inner.result_bus.record_lagged(skipped);
+    }
+
+    pub fn result_schema() -> &'static str {
+        AiResultBus::schema()
     }
 
     pub async fn list_projects(&self) -> anyhow::Result<Vec<AiProjectSummary>> {
@@ -531,6 +586,11 @@ impl AiManager {
             .hub
             .configure_input(document.manifest.input.clone())
             .await?;
+        *self.inner.active_inference.write().unwrap() = Some(InferenceDescriptor {
+            project: document.manifest.id.clone(),
+            algorithm: document.manifest.algorithm.clone(),
+            model: document.manifest.model.clone(),
+        });
         *self.inner.last_media_generation.lock().await = self.inner.hub.status().generation.clone();
         {
             let mut status = self.inner.status.write().unwrap();
@@ -606,6 +666,7 @@ impl AiManager {
                         {
                             break;
                         }
+                        manager.finish_result_generation("worker_exited");
                         let current = manager.inner.status.read().unwrap().generation.clone();
                         if current.as_deref() == Some(&active_generation) {
                             let mut status = manager.inner.status.write().unwrap();
@@ -715,6 +776,7 @@ impl AiManager {
     }
 
     async fn stop_runtime(&self) {
+        self.finish_result_generation("worker_stopped");
         if let Some(runtime) = self.inner.runtime.lock().await.take() {
             self.inner
                 .intentional_stops
@@ -736,7 +798,13 @@ impl AiManager {
         }
         self.inner.metadata_history.write().unwrap().clear();
         *self.inner.last_metadata.write().unwrap() = None;
-        *self.inner.tracker.lock().await = Tracker::default();
+        *self.inner.tracker.lock().await = Tracker::new(
+            self.inner
+                .config
+                .track_lost_timeout_ms
+                .saturating_mul(1_000),
+        );
+        *self.inner.active_inference.write().unwrap() = None;
         self.clear_embedded_regions().await;
     }
 
@@ -921,6 +989,20 @@ impl AiManager {
         });
     }
 
+    fn spawn_result_lifecycle_loop(&self) {
+        let manager = self.clone();
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(Duration::from_millis(100));
+            loop {
+                tick.tick().await;
+                let exited = manager.inner.lifecycle.lock().unwrap().expire(now_ms());
+                for event in exited {
+                    manager.publish_track_event(TRACK_EXITED_TYPE, event);
+                }
+            }
+        });
+    }
+
     async fn clear_embedded_regions(&self) -> bool {
         if self.inner.status.read().unwrap().osd_mode != OsdMode::EmbeddedRgn {
             return true;
@@ -993,7 +1075,58 @@ impl AiManager {
                 height: (y2 - y1).abs(),
             });
         }
-        let detections = self.inner.tracker.lock().await.update(boxes, frame.pts);
+        let detections =
+            self.inner
+                .tracker
+                .lock()
+                .await
+                .update(boxes, frame.pts, &frame.generation);
+        let descriptor = self
+            .inner
+            .active_inference
+            .read()
+            .unwrap()
+            .clone()
+            .unwrap_or_else(|| InferenceDescriptor {
+                project: "unknown".into(),
+                algorithm: "unknown".into(),
+                model: "unknown".into(),
+            });
+        let published_at_ms = now_ms();
+        self.publish_standard_result(AiResultInput {
+            source_id: self.inner.config.source_id.clone(),
+            media_generation: frame.generation.clone(),
+            ai_generation: generation.to_owned(),
+            sequence,
+            pts_us: frame.pts,
+            published_at_ms,
+            frame: AiFrameInfoV1 {
+                width: frame.main_width,
+                height: frame.main_height,
+                coordinate_space: "main_normalized_top_left".into(),
+            },
+            inference: AiInferenceInfoV1 {
+                project: descriptor.project,
+                algorithm: descriptor.algorithm,
+                model: descriptor.model,
+                duration_us: inference_us,
+            },
+            objects: detections
+                .iter()
+                .map(|detection| AiObjectV1 {
+                    track_id: detection.track_id,
+                    class_id: detection.class_id,
+                    label: detection.label.clone(),
+                    confidence: detection.confidence,
+                    bbox: AiBoundingBoxV1 {
+                        x: detection.x,
+                        y: detection.y,
+                        width: detection.width,
+                        height: detection.height,
+                    },
+                })
+                .collect(),
+        });
         let metadata = Arc::new(AiMetadata {
             version: 1,
             generation: generation.to_owned(),
@@ -1022,7 +1155,7 @@ impl AiManager {
             });
         }
         let _ = self.inner.metadata.send(metadata.clone());
-        let observed_at = now_ms();
+        let observed_at = published_at_ms;
         let mut status = self.inner.status.write().unwrap();
         if let Some(previous) = status.last_result_at_ms {
             let elapsed_ms = observed_at.saturating_sub(previous);
@@ -1045,6 +1178,69 @@ impl AiManager {
             serde_json::to_value(&*metadata)?,
         ));
         Ok(())
+    }
+
+    fn publish_standard_result(&self, input: AiResultInput) {
+        let batch = self.inner.lifecycle.lock().unwrap().observe(&input);
+        for event in batch.exited {
+            self.publish_track_event(TRACK_EXITED_TYPE, event);
+        }
+        if let Some(event) = batch.generation {
+            self.publish_generation_event(event);
+        }
+        self.inner.result_bus.publish(
+            FRAME_RESULT_TYPE,
+            format!("frame/{}/{}", input.media_generation, input.sequence),
+            &input.data(),
+            true,
+        );
+        for event in batch.entered {
+            self.publish_track_event(TRACK_ENTERED_TYPE, event);
+        }
+        for event in batch.updated {
+            self.publish_track_event(TRACK_UPDATED_TYPE, event);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn publish_test_result(&self, input: AiResultInput) {
+        self.publish_standard_result(input);
+    }
+
+    fn publish_track_event(&self, event_type: &str, event: AiTrackEventDataV1) {
+        self.inner.result_bus.publish(
+            event_type,
+            format!("track/{}/{}", event.ai_generation, event.object.track_id),
+            &event,
+            false,
+        );
+    }
+
+    fn publish_generation_event(&self, event: AiGenerationEventDataV1) {
+        let subject = event
+            .ai_generation
+            .as_deref()
+            .or(event.previous_ai_generation.as_deref())
+            .map(|generation| format!("generation/{generation}"))
+            .unwrap_or_else(|| "generation/none".into());
+        self.inner
+            .result_bus
+            .publish(GENERATION_TYPE, subject, &event, false);
+    }
+
+    fn finish_result_generation(&self, reason: &str) {
+        let finish = self
+            .inner
+            .lifecycle
+            .lock()
+            .unwrap()
+            .finish(reason, now_ms());
+        for event in finish.exited {
+            self.publish_track_event(TRACK_EXITED_TYPE, event);
+        }
+        if let Some(event) = finish.generation {
+            self.publish_generation_event(event);
+        }
     }
 
     pub async fn list_models(&self) -> anyhow::Result<Vec<AiModelInfo>> {

--- a/aipc-daemon/src/ai_manager/tracking.rs
+++ b/aipc-daemon/src/ai_manager/tracking.rs
@@ -4,10 +4,11 @@ use serde_json::Value;
 use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
-#[derive(Default)]
 pub(super) struct Tracker {
     next_id: u64,
     previous: Vec<(u64, UntrackedDetection, u64)>,
+    retention_us: u64,
+    media_generation: Option<String>,
 }
 
 #[derive(Clone)]
@@ -22,11 +23,25 @@ pub(super) struct UntrackedDetection {
 }
 
 impl Tracker {
+    pub(super) fn new(retention_us: u64) -> Self {
+        Self {
+            next_id: 0,
+            previous: Vec::new(),
+            retention_us,
+            media_generation: None,
+        }
+    }
+
     pub(super) fn update(
         &mut self,
         current: Vec<UntrackedDetection>,
         pts: u64,
+        media_generation: &str,
     ) -> Vec<AiDetection> {
+        if self.media_generation.as_deref() != Some(media_generation) {
+            self.previous.clear();
+            self.media_generation = Some(media_generation.into());
+        }
         let mut used = vec![false; self.previous.len()];
         let mut output = Vec::new();
         let mut next_previous = Vec::new();
@@ -59,6 +74,11 @@ impl Tracker {
                 height: item.height,
             });
             next_previous.push((track_id, item, pts));
+        }
+        for (index, previous) in self.previous.iter().enumerate() {
+            if !used[index] && pts.saturating_sub(previous.2) <= self.retention_us {
+                next_previous.push(previous.clone());
+            }
         }
         self.previous = next_previous;
         output
@@ -191,4 +211,31 @@ pub(super) fn number(value: &Value, key: &str) -> anyhow::Result<f64> {
         .get(key)
         .and_then(Value::as_f64)
         .ok_or_else(|| anyhow::anyhow!("detection field {key} is missing"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn detection(x: f64) -> UntrackedDetection {
+        UntrackedDetection {
+            class_id: 0,
+            label: "person".into(),
+            confidence: 0.9,
+            x,
+            y: 0.1,
+            width: 0.2,
+            height: 0.3,
+        }
+    }
+
+    #[test]
+    fn media_generation_change_starts_new_track_ids() {
+        let mut tracker = Tracker::new(500_000);
+        let first = tracker.update(vec![detection(0.1)], 100, "media-1");
+        let same = tracker.update(vec![detection(0.11)], 200, "media-1");
+        let restarted = tracker.update(vec![detection(0.11)], 10, "media-2");
+        assert_eq!(first[0].track_id, same[0].track_id);
+        assert_ne!(first[0].track_id, restarted[0].track_id);
+    }
 }

--- a/aipc-daemon/src/ai_result_schema.json
+++ b/aipc-daemon/src/ai_result_schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "/api/v1/ai/results/schema",
+  "title": "AIPC AI CloudEvent v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["specversion", "id", "source", "type", "subject", "time", "datacontenttype", "dataschema", "data"],
+  "properties": {
+    "specversion": { "const": "1.0" },
+    "id": { "type": "string", "minLength": 3 },
+    "source": { "type": "string", "pattern": "^urn:aipc:camera:" },
+    "type": {
+      "enum": [
+        "io.aipc.ai.frame.v1",
+        "io.aipc.ai.track.entered.v1",
+        "io.aipc.ai.track.updated.v1",
+        "io.aipc.ai.track.exited.v1",
+        "io.aipc.ai.stream.gap.v1",
+        "io.aipc.ai.generation.v1"
+      ]
+    },
+    "subject": { "type": "string" },
+    "time": { "type": "string", "format": "date-time" },
+    "datacontenttype": { "const": "application/json" },
+    "dataschema": { "const": "/api/v1/ai/results/schema" },
+    "data": {
+      "oneOf": [
+        { "$ref": "#/$defs/frameResult" },
+        { "$ref": "#/$defs/trackEvent" },
+        { "$ref": "#/$defs/generationEvent" },
+        { "$ref": "#/$defs/streamGap" }
+      ]
+    }
+  },
+  "$defs": {
+    "bbox": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y", "width", "height"],
+      "properties": {
+        "x": { "type": "number", "minimum": 0, "maximum": 1 },
+        "y": { "type": "number", "minimum": 0, "maximum": 1 },
+        "width": { "type": "number", "minimum": 0, "maximum": 1 },
+        "height": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "object": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["track_id", "class_id", "label", "confidence", "bbox"],
+      "properties": {
+        "track_id": { "type": "integer", "minimum": 1 },
+        "class_id": { "type": "integer" },
+        "label": { "type": "string", "maxLength": 128 },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "bbox": { "$ref": "#/$defs/bbox" }
+      }
+    },
+    "frame": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["width", "height", "coordinate_space"],
+      "properties": {
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 },
+        "coordinate_space": { "const": "main_normalized_top_left" }
+      }
+    },
+    "inference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["project", "algorithm", "model", "duration_us"],
+      "properties": {
+        "project": { "type": "string" },
+        "algorithm": { "type": "string" },
+        "model": { "type": "string" },
+        "duration_us": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "common": {
+      "type": "object",
+      "required": ["schema_version", "source_id", "media_generation", "ai_generation", "sequence", "pts_us", "published_at_ms", "frame", "inference"],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "source_id": { "type": "string" },
+        "media_generation": { "type": "string" },
+        "ai_generation": { "type": "string" },
+        "sequence": { "type": "integer", "minimum": 0 },
+        "pts_us": { "type": "integer", "minimum": 0 },
+        "published_at_ms": { "type": "integer", "minimum": 0 },
+        "frame": { "$ref": "#/$defs/frame" },
+        "inference": { "$ref": "#/$defs/inference" }
+      }
+    },
+    "frameResult": {
+      "allOf": [
+        { "$ref": "#/$defs/common" },
+        {
+          "type": "object",
+          "required": ["objects"],
+          "properties": { "objects": { "type": "array", "maxItems": 256, "items": { "$ref": "#/$defs/object" } } }
+        }
+      ]
+    },
+    "trackEvent": {
+      "allOf": [
+        { "$ref": "#/$defs/common" },
+        {
+          "type": "object",
+          "required": ["object", "reason"],
+          "properties": {
+            "object": { "$ref": "#/$defs/object" },
+            "reason": { "type": "string" }
+          }
+        }
+      ]
+    },
+    "generationEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "source_id", "media_generation", "ai_generation", "previous_media_generation", "previous_ai_generation", "state", "reason", "published_at_ms"],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "source_id": { "type": "string" },
+        "media_generation": { "type": ["string", "null"] },
+        "ai_generation": { "type": ["string", "null"] },
+        "previous_media_generation": { "type": ["string", "null"] },
+        "previous_ai_generation": { "type": ["string", "null"] },
+        "state": { "enum": ["started", "stopped"] },
+        "reason": { "type": "string" },
+        "published_at_ms": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "streamGap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "source_id", "requested_event_id", "earliest_event_id", "latest_event_id", "reason"],
+      "properties": {
+        "schema_version": { "const": 1 },
+        "source_id": { "type": "string" },
+        "requested_event_id": { "type": ["string", "null"] },
+        "earliest_event_id": { "type": ["string", "null"] },
+        "latest_event_id": { "type": ["string", "null"] },
+        "reason": { "type": "string" }
+      }
+    }
+  }
+}

--- a/aipc-daemon/src/ai_results.rs
+++ b/aipc-daemon/src/ai_results.rs
@@ -1,0 +1,807 @@
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+use tokio::sync::broadcast;
+use uuid::Uuid;
+
+pub const FRAME_RESULT_TYPE: &str = "io.aipc.ai.frame.v1";
+pub const TRACK_ENTERED_TYPE: &str = "io.aipc.ai.track.entered.v1";
+pub const TRACK_UPDATED_TYPE: &str = "io.aipc.ai.track.updated.v1";
+pub const TRACK_EXITED_TYPE: &str = "io.aipc.ai.track.exited.v1";
+pub const STREAM_GAP_TYPE: &str = "io.aipc.ai.stream.gap.v1";
+pub const GENERATION_TYPE: &str = "io.aipc.ai.generation.v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AiBoundingBoxV1 {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AiObjectV1 {
+    pub track_id: u64,
+    pub class_id: i64,
+    pub label: String,
+    pub confidence: f64,
+    pub bbox: AiBoundingBoxV1,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AiFrameInfoV1 {
+    pub width: u32,
+    pub height: u32,
+    pub coordinate_space: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AiInferenceInfoV1 {
+    pub project: String,
+    pub algorithm: String,
+    pub model: String,
+    pub duration_us: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AiResultDataV1 {
+    pub schema_version: u32,
+    pub source_id: String,
+    pub media_generation: String,
+    pub ai_generation: String,
+    pub sequence: u64,
+    pub pts_us: u64,
+    pub published_at_ms: u64,
+    pub frame: AiFrameInfoV1,
+    pub inference: AiInferenceInfoV1,
+    pub objects: Vec<AiObjectV1>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AiTrackEventDataV1 {
+    pub schema_version: u32,
+    pub source_id: String,
+    pub media_generation: String,
+    pub ai_generation: String,
+    pub sequence: u64,
+    pub pts_us: u64,
+    pub published_at_ms: u64,
+    pub frame: AiFrameInfoV1,
+    pub inference: AiInferenceInfoV1,
+    pub object: AiObjectV1,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AiGenerationEventDataV1 {
+    pub schema_version: u32,
+    pub source_id: String,
+    pub media_generation: Option<String>,
+    pub ai_generation: Option<String>,
+    pub previous_media_generation: Option<String>,
+    pub previous_ai_generation: Option<String>,
+    pub state: String,
+    pub reason: String,
+    pub published_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AiStreamGapDataV1 {
+    pub schema_version: u32,
+    pub source_id: String,
+    pub requested_event_id: Option<String>,
+    pub earliest_event_id: Option<String>,
+    pub latest_event_id: Option<String>,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AiCloudEvent {
+    pub specversion: String,
+    pub id: String,
+    pub source: String,
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub subject: String,
+    pub time: String,
+    pub datacontenttype: String,
+    pub dataschema: String,
+    pub data: Value,
+}
+
+impl AiCloudEvent {
+    pub fn sequence(&self) -> Option<u64> {
+        self.id.rsplit_once(':')?.1.parse().ok()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AiResultBusStatus {
+    pub stream_id: String,
+    pub latest_event_id: Option<String>,
+    pub earliest_replay_event_id: Option<String>,
+    pub published: u64,
+    pub replay_depth: usize,
+    pub replay_capacity: usize,
+    pub lagged_events: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct AiResultInput {
+    pub source_id: String,
+    pub media_generation: String,
+    pub ai_generation: String,
+    pub sequence: u64,
+    pub pts_us: u64,
+    pub published_at_ms: u64,
+    pub frame: AiFrameInfoV1,
+    pub inference: AiInferenceInfoV1,
+    pub objects: Vec<AiObjectV1>,
+}
+
+impl AiResultInput {
+    pub fn data(&self) -> AiResultDataV1 {
+        AiResultDataV1 {
+            schema_version: 1,
+            source_id: self.source_id.clone(),
+            media_generation: self.media_generation.clone(),
+            ai_generation: self.ai_generation.clone(),
+            sequence: self.sequence,
+            pts_us: self.pts_us,
+            published_at_ms: self.published_at_ms,
+            frame: self.frame.clone(),
+            inference: self.inference.clone(),
+            objects: self.objects.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct AiResultSubscription {
+    pub receiver: broadcast::Receiver<Arc<AiCloudEvent>>,
+    pub pending: VecDeque<Arc<AiCloudEvent>>,
+    pub last_sequence: u64,
+}
+
+struct BusState {
+    stream_id: String,
+    next_sequence: u64,
+    published: u64,
+    lagged_events: u64,
+    replay: VecDeque<Arc<AiCloudEvent>>,
+    latest_frame: Option<Arc<AiCloudEvent>>,
+}
+
+#[derive(Clone)]
+pub struct AiResultBus {
+    source: String,
+    schema_url: String,
+    replay_capacity: usize,
+    sender: broadcast::Sender<Arc<AiCloudEvent>>,
+    state: Arc<StdMutex<BusState>>,
+}
+
+impl AiResultBus {
+    pub fn new(source_id: String, replay_capacity: usize) -> Self {
+        let capacity = replay_capacity.max(1);
+        let (sender, _) = broadcast::channel(capacity.max(32));
+        let stream_id = Uuid::new_v4().to_string();
+        Self {
+            source: format!("urn:aipc:camera:{source_id}"),
+            schema_url: "/api/v1/ai/results/schema".into(),
+            replay_capacity: capacity,
+            sender,
+            state: Arc::new(StdMutex::new(BusState {
+                stream_id,
+                next_sequence: 0,
+                published: 0,
+                lagged_events: 0,
+                replay: VecDeque::with_capacity(capacity),
+                latest_frame: None,
+            })),
+        }
+    }
+
+    pub fn publish<T: Serialize>(
+        &self,
+        event_type: &str,
+        subject: String,
+        data: &T,
+        latest_frame: bool,
+    ) -> Arc<AiCloudEvent> {
+        let event = {
+            let mut state = self.state.lock().unwrap();
+            state.next_sequence += 1;
+            state.published += 1;
+            let id = format!("{}:{}", state.stream_id, state.next_sequence);
+            let event = Arc::new(AiCloudEvent {
+                specversion: "1.0".into(),
+                id,
+                source: self.source.clone(),
+                event_type: event_type.into(),
+                subject,
+                time: utc_rfc3339(),
+                datacontenttype: "application/json".into(),
+                dataschema: self.schema_url.clone(),
+                data: serde_json::to_value(data).unwrap_or_else(|_| json!({})),
+            });
+            if state.replay.len() == self.replay_capacity {
+                state.replay.pop_front();
+            }
+            state.replay.push_back(event.clone());
+            if latest_frame {
+                state.latest_frame = Some(event.clone());
+            }
+            event
+        };
+        let _ = self.sender.send(event.clone());
+        event
+    }
+
+    pub fn latest(&self) -> Option<Arc<AiCloudEvent>> {
+        self.state.lock().unwrap().latest_frame.clone()
+    }
+
+    pub fn record_lagged(&self, skipped: u64) {
+        let mut state = self.state.lock().unwrap();
+        state.lagged_events = state.lagged_events.saturating_add(skipped);
+    }
+
+    pub fn status(&self) -> AiResultBusStatus {
+        let state = self.state.lock().unwrap();
+        AiResultBusStatus {
+            stream_id: state.stream_id.clone(),
+            latest_event_id: state.replay.back().map(|event| event.id.clone()),
+            earliest_replay_event_id: state.replay.front().map(|event| event.id.clone()),
+            published: state.published,
+            replay_depth: state.replay.len(),
+            replay_capacity: self.replay_capacity,
+            lagged_events: state.lagged_events,
+        }
+    }
+
+    pub fn subscribe_from(&self, cursor: Option<&str>) -> AiResultSubscription {
+        let receiver = self.sender.subscribe();
+        let (pending, last_sequence) = self.replay_after(cursor);
+        AiResultSubscription {
+            receiver,
+            pending,
+            last_sequence,
+        }
+    }
+
+    pub fn replay_after_sequence(&self, sequence: u64) -> (VecDeque<Arc<AiCloudEvent>>, u64) {
+        let (pending, cursor) = self.replay_after_sequence_inner(sequence, None);
+        (pending, cursor)
+    }
+
+    fn replay_after(&self, cursor: Option<&str>) -> (VecDeque<Arc<AiCloudEvent>>, u64) {
+        let Some(cursor) = cursor else {
+            return (VecDeque::new(), 0);
+        };
+        let Some((stream, sequence)) = cursor.rsplit_once(':') else {
+            return self.gap_for(Some(cursor));
+        };
+        let sequence = match sequence.parse::<u64>() {
+            Ok(sequence) => sequence,
+            Err(_) => return self.gap_for(Some(cursor)),
+        };
+        let expected_stream = self.state.lock().unwrap().stream_id.clone();
+        if stream != expected_stream {
+            return self.gap_for(Some(cursor));
+        }
+        self.replay_after_sequence_inner(sequence, Some(cursor))
+    }
+
+    fn replay_after_sequence_inner(
+        &self,
+        sequence: u64,
+        requested: Option<&str>,
+    ) -> (VecDeque<Arc<AiCloudEvent>>, u64) {
+        let state = self.state.lock().unwrap();
+        let earliest = state.replay.front().and_then(|event| event.sequence());
+        let latest = state.replay.back().and_then(|event| event.sequence());
+        let too_old = earliest.is_some_and(|earliest| sequence.saturating_add(1) < earliest);
+        let too_new = latest.is_some_and(|latest| sequence > latest);
+        if too_old || too_new {
+            drop(state);
+            return self.gap_for(requested);
+        }
+        let pending = state
+            .replay
+            .iter()
+            .filter(|event| event.sequence().is_some_and(|item| item > sequence))
+            .cloned()
+            .collect();
+        (pending, sequence)
+    }
+
+    fn gap_for(&self, requested: Option<&str>) -> (VecDeque<Arc<AiCloudEvent>>, u64) {
+        let event = {
+            let mut state = self.state.lock().unwrap();
+            state.next_sequence += 1;
+            let id = format!("{}:{}", state.stream_id, state.next_sequence);
+            let earliest = state.replay.front().map(|item| item.id.clone());
+            let latest = state.replay.back().map(|item| item.id.clone());
+            Arc::new(AiCloudEvent {
+                specversion: "1.0".into(),
+                id,
+                source: self.source.clone(),
+                event_type: STREAM_GAP_TYPE.into(),
+                subject: "stream".into(),
+                time: utc_rfc3339(),
+                datacontenttype: "application/json".into(),
+                dataschema: self.schema_url.clone(),
+                data: serde_json::to_value(AiStreamGapDataV1 {
+                    schema_version: 1,
+                    source_id: self.source.trim_start_matches("urn:aipc:camera:").into(),
+                    requested_event_id: requested.map(str::to_owned),
+                    earliest_event_id: earliest,
+                    latest_event_id: latest,
+                    reason: "replay_cursor_out_of_range".into(),
+                })
+                .unwrap_or_else(|_| json!({})),
+            })
+        };
+        let sequence = event.sequence().unwrap_or_default();
+        (VecDeque::from([event]), sequence)
+    }
+
+    pub fn schema() -> &'static str {
+        include_str!("ai_result_schema.json")
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TrackState {
+    object: AiObjectV1,
+    context: TrackContext,
+    seen_count: u32,
+    confirmed: bool,
+    last_seen_ms: u64,
+    last_emitted_ms: u64,
+    last_emitted_object: AiObjectV1,
+}
+
+#[derive(Debug, Clone)]
+struct TrackContext {
+    source_id: String,
+    media_generation: String,
+    ai_generation: String,
+    sequence: u64,
+    pts_us: u64,
+    frame: AiFrameInfoV1,
+    inference: AiInferenceInfoV1,
+}
+
+impl TrackContext {
+    fn from_input(input: &AiResultInput) -> Self {
+        Self {
+            source_id: input.source_id.clone(),
+            media_generation: input.media_generation.clone(),
+            ai_generation: input.ai_generation.clone(),
+            sequence: input.sequence,
+            pts_us: input.pts_us,
+            frame: input.frame.clone(),
+            inference: input.inference.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct AiLifecycleTracker {
+    current_source_id: Option<String>,
+    current_media_generation: Option<String>,
+    current_ai_generation: Option<String>,
+    tracks: HashMap<u64, TrackState>,
+    confirmations: u32,
+    lost_timeout: Duration,
+    update_interval: Duration,
+}
+
+impl AiLifecycleTracker {
+    pub fn new(confirmations: usize, lost_timeout_ms: u64, update_interval_ms: u64) -> Self {
+        Self {
+            confirmations: confirmations.max(1) as u32,
+            lost_timeout: Duration::from_millis(lost_timeout_ms.max(1)),
+            update_interval: Duration::from_millis(update_interval_ms.max(1)),
+            ..Self::default()
+        }
+    }
+
+    pub fn observe(&mut self, input: &AiResultInput) -> LifecycleBatch {
+        let generation_changed = self.current_media_generation.as_deref()
+            != Some(input.media_generation.as_str())
+            || self.current_ai_generation.as_deref() != Some(input.ai_generation.as_str());
+        let mut exited = Vec::new();
+        let previous_media_generation = self.current_media_generation.clone();
+        let previous_ai_generation = self.current_ai_generation.clone();
+        if generation_changed {
+            for state in self.tracks.values() {
+                if state.confirmed {
+                    exited.push(track_event_data(
+                        &state.context,
+                        state.object.clone(),
+                        "generation_changed",
+                        input.published_at_ms,
+                    ));
+                }
+            }
+            self.tracks.clear();
+            self.current_source_id = Some(input.source_id.clone());
+            self.current_media_generation = Some(input.media_generation.clone());
+            self.current_ai_generation = Some(input.ai_generation.clone());
+        }
+        let mut present = HashSet::new();
+        let context = TrackContext::from_input(input);
+        let mut entered = Vec::new();
+        let mut updated = Vec::new();
+        for object in &input.objects {
+            present.insert(object.track_id);
+            let state = self
+                .tracks
+                .entry(object.track_id)
+                .or_insert_with(|| TrackState {
+                    object: object.clone(),
+                    context: context.clone(),
+                    seen_count: 0,
+                    confirmed: false,
+                    last_seen_ms: input.published_at_ms,
+                    last_emitted_ms: 0,
+                    last_emitted_object: object.clone(),
+                });
+            state.object = object.clone();
+            state.context = context.clone();
+            state.seen_count = state.seen_count.saturating_add(1);
+            state.last_seen_ms = input.published_at_ms;
+            if !state.confirmed && state.seen_count >= self.confirmations {
+                state.confirmed = true;
+                state.last_emitted_ms = input.published_at_ms;
+                state.last_emitted_object = object.clone();
+                entered.push(track_event_data(
+                    &context,
+                    object.clone(),
+                    "confirmed",
+                    input.published_at_ms,
+                ));
+            } else if state.confirmed
+                && let Some(reason) =
+                    update_reason(state, object, input.published_at_ms, self.update_interval)
+            {
+                state.last_emitted_ms = input.published_at_ms;
+                state.last_emitted_object = object.clone();
+                updated.push(track_event_data(
+                    &context,
+                    object.clone(),
+                    reason,
+                    input.published_at_ms,
+                ));
+            }
+        }
+        exited.extend(self.expire_except(input.published_at_ms, &present));
+        LifecycleBatch {
+            generation: if generation_changed {
+                Some(AiGenerationEventDataV1 {
+                    schema_version: 1,
+                    source_id: input.source_id.clone(),
+                    media_generation: Some(input.media_generation.clone()),
+                    ai_generation: Some(input.ai_generation.clone()),
+                    previous_media_generation,
+                    previous_ai_generation,
+                    state: "started".into(),
+                    reason: "generation_changed".into(),
+                    published_at_ms: input.published_at_ms,
+                })
+            } else {
+                None
+            },
+            exited,
+            entered,
+            updated,
+        }
+    }
+
+    pub fn finish(&mut self, reason: &str, published_at_ms: u64) -> LifecycleFinish {
+        let mut exited = Vec::new();
+        for state in self.tracks.values() {
+            if state.confirmed {
+                exited.push(track_event_data(
+                    &state.context,
+                    state.object.clone(),
+                    reason,
+                    published_at_ms,
+                ));
+            }
+        }
+        let generation = self
+            .current_ai_generation
+            .as_ref()
+            .map(|_| AiGenerationEventDataV1 {
+                schema_version: 1,
+                source_id: self
+                    .current_source_id
+                    .clone()
+                    .unwrap_or_else(|| "camera0".into()),
+                media_generation: None,
+                ai_generation: None,
+                previous_media_generation: self.current_media_generation.clone(),
+                previous_ai_generation: self.current_ai_generation.clone(),
+                state: "stopped".into(),
+                reason: reason.into(),
+                published_at_ms,
+            });
+        self.tracks.clear();
+        self.current_source_id = None;
+        self.current_media_generation = None;
+        self.current_ai_generation = None;
+        LifecycleFinish { generation, exited }
+    }
+
+    pub fn expire(&mut self, now_ms: u64) -> Vec<AiTrackEventDataV1> {
+        self.expire_except(now_ms, &HashSet::new())
+    }
+
+    fn expire_except(&mut self, now_ms: u64, present: &HashSet<u64>) -> Vec<AiTrackEventDataV1> {
+        let stale: Vec<u64> = self
+            .tracks
+            .iter()
+            .filter(|(track_id, state)| {
+                !present.contains(track_id)
+                    && now_ms.saturating_sub(state.last_seen_ms)
+                        >= self.lost_timeout.as_millis() as u64
+            })
+            .map(|(track_id, _)| *track_id)
+            .collect();
+        let mut exited = Vec::new();
+        for track_id in stale {
+            if let Some(state) = self.tracks.remove(&track_id)
+                && state.confirmed
+            {
+                exited.push(track_event_data(
+                    &state.context,
+                    state.object,
+                    "lost_timeout",
+                    now_ms,
+                ));
+            }
+        }
+        exited
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct LifecycleBatch {
+    pub generation: Option<AiGenerationEventDataV1>,
+    pub exited: Vec<AiTrackEventDataV1>,
+    pub entered: Vec<AiTrackEventDataV1>,
+    pub updated: Vec<AiTrackEventDataV1>,
+}
+
+#[derive(Debug, Default)]
+pub struct LifecycleFinish {
+    pub generation: Option<AiGenerationEventDataV1>,
+    pub exited: Vec<AiTrackEventDataV1>,
+}
+
+fn track_event_data(
+    context: &TrackContext,
+    object: AiObjectV1,
+    reason: &str,
+    published_at_ms: u64,
+) -> AiTrackEventDataV1 {
+    AiTrackEventDataV1 {
+        schema_version: 1,
+        source_id: context.source_id.clone(),
+        media_generation: context.media_generation.clone(),
+        ai_generation: context.ai_generation.clone(),
+        sequence: context.sequence,
+        pts_us: context.pts_us,
+        published_at_ms,
+        frame: context.frame.clone(),
+        inference: context.inference.clone(),
+        object,
+        reason: reason.into(),
+    }
+}
+
+fn update_reason(
+    state: &TrackState,
+    current: &AiObjectV1,
+    now_ms: u64,
+    interval: Duration,
+) -> Option<&'static str> {
+    let elapsed = now_ms.saturating_sub(state.last_emitted_ms);
+    let significant = iou(&state.last_emitted_object.bbox, &current.bbox) < 0.85
+        || (state.last_emitted_object.confidence - current.confidence).abs() >= 0.1
+        || state.last_emitted_object.class_id != current.class_id
+        || state.last_emitted_object.label != current.label;
+    if significant {
+        Some("changed")
+    } else if elapsed >= interval.as_millis() as u64 {
+        Some("heartbeat")
+    } else {
+        None
+    }
+}
+
+fn iou(left: &AiBoundingBoxV1, right: &AiBoundingBoxV1) -> f64 {
+    let x1 = left.x.max(right.x);
+    let y1 = left.y.max(right.y);
+    let x2 = (left.x + left.width).min(right.x + right.width);
+    let y2 = (left.y + left.height).min(right.y + right.height);
+    let intersection = (x2 - x1).max(0.0) * (y2 - y1).max(0.0);
+    let union = left.width * left.height + right.width * right.height - intersection;
+    if union <= 0.0 {
+        0.0
+    } else {
+        intersection / union
+    }
+}
+
+fn utc_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input(sequence: u64, pts_us: u64, x: f64) -> AiResultInput {
+        AiResultInput {
+            source_id: "camera0".into(),
+            media_generation: "media-1".into(),
+            ai_generation: "ai-1".into(),
+            sequence,
+            pts_us,
+            published_at_ms: sequence * 100,
+            frame: AiFrameInfoV1 {
+                width: 1920,
+                height: 1080,
+                coordinate_space: "main_normalized_top_left".into(),
+            },
+            inference: AiInferenceInfoV1 {
+                project: "test".into(),
+                algorithm: "yolov5".into(),
+                model: "model.rknn".into(),
+                duration_us: 10,
+            },
+            objects: vec![AiObjectV1 {
+                track_id: 1,
+                class_id: 0,
+                label: "person".into(),
+                confidence: 0.9,
+                bbox: AiBoundingBoxV1 {
+                    x,
+                    y: 0.2,
+                    width: 0.2,
+                    height: 0.3,
+                },
+            }],
+        }
+    }
+
+    #[test]
+    fn cloud_event_has_stable_required_fields() {
+        let bus = AiResultBus::new("camera0".into(), 4);
+        let event = bus.publish(
+            FRAME_RESULT_TYPE,
+            "frame/ai-1/1".into(),
+            &input(1, 1, 0.1).data(),
+            true,
+        );
+        assert_eq!(event.specversion, "1.0");
+        assert!(event.id.ends_with(":1"));
+        assert_eq!(event.event_type, FRAME_RESULT_TYPE);
+        assert_eq!(
+            event.data["frame"]["coordinate_space"],
+            "main_normalized_top_left"
+        );
+    }
+
+    #[test]
+    fn replay_reports_gap_for_expired_cursor() {
+        let bus = AiResultBus::new("camera0".into(), 2);
+        let first = bus.publish(
+            FRAME_RESULT_TYPE,
+            "frame/1".into(),
+            &input(1, 1, 0.1).data(),
+            true,
+        );
+        bus.publish(
+            FRAME_RESULT_TYPE,
+            "frame/2".into(),
+            &input(2, 2, 0.1).data(),
+            true,
+        );
+        bus.publish(
+            FRAME_RESULT_TYPE,
+            "frame/3".into(),
+            &input(3, 3, 0.1).data(),
+            true,
+        );
+        bus.publish(
+            FRAME_RESULT_TYPE,
+            "frame/4".into(),
+            &input(4, 4, 0.1).data(),
+            true,
+        );
+        let subscription = bus.subscribe_from(Some(&first.id));
+        assert_eq!(subscription.pending[0].event_type, STREAM_GAP_TYPE);
+    }
+
+    #[test]
+    fn lifecycle_requires_confirmation_and_emits_exit() {
+        let mut tracker = AiLifecycleTracker::new(2, 500, 500);
+        assert!(tracker.observe(&input(1, 1, 0.1)).entered.is_empty());
+        assert_eq!(tracker.observe(&input(2, 2, 0.1)).entered.len(), 1);
+        let mut missing = input(8, 8, 0.1);
+        missing.objects.clear();
+        assert_eq!(tracker.observe(&missing).exited.len(), 1);
+    }
+
+    #[test]
+    fn slow_subscriber_never_blocks_result_publish() {
+        let bus = AiResultBus::new("camera0".into(), 4);
+        let _subscriber = bus.subscribe_from(None);
+        for sequence in 1..=1000 {
+            bus.publish(
+                FRAME_RESULT_TYPE,
+                format!("frame/{sequence}"),
+                &input(sequence, sequence, 0.1).data(),
+                true,
+            );
+        }
+        let status = bus.status();
+        assert_eq!(status.published, 1000);
+        assert_eq!(status.replay_depth, 4);
+        assert!(status.latest_event_id.unwrap().ends_with(":1000"));
+    }
+
+    #[test]
+    fn generation_change_exits_confirmed_tracks() {
+        let mut tracker = AiLifecycleTracker::new(1, 500, 500);
+        assert_eq!(tracker.observe(&input(1, 1, 0.1)).entered.len(), 1);
+        let mut next = input(2, 2, 0.1);
+        next.ai_generation = "ai-2".into();
+        let batch = tracker.observe(&next);
+        assert_eq!(batch.exited.len(), 1);
+        assert_eq!(batch.exited[0].reason, "generation_changed");
+        assert_eq!(
+            batch.generation.unwrap().ai_generation.as_deref(),
+            Some("ai-2")
+        );
+    }
+
+    #[test]
+    fn lifecycle_expires_without_another_inference_result() {
+        let mut tracker = AiLifecycleTracker::new(1, 500, 500);
+        assert_eq!(tracker.observe(&input(1, 1, 0.1)).entered.len(), 1);
+        assert!(tracker.expire(599).is_empty());
+        let exited = tracker.expire(600);
+        assert_eq!(exited.len(), 1);
+        assert_eq!(exited[0].published_at_ms, 600);
+    }
+
+    #[test]
+    fn generation_exit_uses_transition_publish_time() {
+        let mut tracker = AiLifecycleTracker::new(1, 500, 500);
+        tracker.observe(&input(1, 1, 0.1));
+        let mut next = input(9, 9, 0.1);
+        next.ai_generation = "ai-2".into();
+        let batch = tracker.observe(&next);
+        assert_eq!(batch.exited[0].published_at_ms, 900);
+    }
+
+    #[test]
+    fn bundled_schema_is_valid_json() {
+        let schema: Value = serde_json::from_str(AiResultBus::schema()).unwrap();
+        assert_eq!(schema["$id"], "/api/v1/ai/results/schema");
+        assert!(schema["$defs"]["frameResult"].is_object());
+    }
+}

--- a/aipc-daemon/src/api.rs
+++ b/aipc-daemon/src/api.rs
@@ -1,5 +1,5 @@
 use crate::ai_manager::{AiManager, AiProjectDocument, OsdMode};
-use crate::config::WorkerConfig;
+use crate::config::{UiConfig, WorkerConfig};
 use crate::preview::PreviewHub;
 use crate::recording::{RecordingManager, RecordingSettingsUpdate};
 use crate::rtsp::RtspServer;
@@ -14,7 +14,7 @@ use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
 use futures_util::stream;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::convert::Infallible;
 use std::net::SocketAddr;
@@ -38,6 +38,7 @@ struct AppState {
     rtsp: RtspServer,
     webrtc: WebRtcServer,
     ai: AiManager,
+    ui: UiConfig,
 }
 
 pub fn router(
@@ -46,12 +47,14 @@ pub fn router(
     rtsp: RtspServer,
     webrtc: WebRtcServer,
     ai: AiManager,
+    ui: UiConfig,
     web_dir: &Path,
 ) -> Router {
     let index = web_dir.join("index.html");
     let static_service = ServeDir::new(web_dir).fallback(ServeFile::new(index));
     Router::new()
         .route("/healthz", get(healthz))
+        .route("/api/v1/about", get(about))
         .route("/api/v1/status", get(status))
         .route("/api/v1/ai/status", get(ai_status))
         .route(
@@ -117,8 +120,23 @@ pub fn router(
             rtsp,
             webrtc,
             ai,
+            ui,
             supervisor,
         })
+}
+
+#[derive(Serialize)]
+struct AboutResponse {
+    #[serde(flatten)]
+    ui: UiConfig,
+    daemon_version: &'static str,
+}
+
+async fn about(State(state): State<AppState>) -> impl IntoResponse {
+    Json(AboutResponse {
+        ui: state.ui,
+        daemon_version: env!("CARGO_PKG_VERSION"),
+    })
 }
 
 #[derive(Deserialize)]
@@ -758,12 +776,18 @@ mod tests {
         )
         .await
         .unwrap();
+        let ui = UiConfig {
+            platform_name: "RK3576".into(),
+            board_name: "Development board".into(),
+            ..UiConfig::default()
+        };
         let app = router(
             handle.clone(),
             recording,
             rtsp,
             webrtc,
             ai.clone(),
+            ui,
             temp.path(),
         );
         let response = app
@@ -777,6 +801,24 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+
+        let response = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/about")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let about: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(about["project_name"], "AIPC");
+        assert_eq!(about["platform_name"], "RK3576");
+        assert_eq!(about["board_name"], "Development board");
+        assert_eq!(about["daemon_version"], env!("CARGO_PKG_VERSION"));
 
         let mut invalid = WorkerConfig::default();
         invalid.video.width = 1;

--- a/aipc-daemon/src/api.rs
+++ b/aipc-daemon/src/api.rs
@@ -73,6 +73,9 @@ pub fn router(
         .route("/api/v1/ai/models/{name}", delete(ai_model_delete))
         .route("/api/v1/ai/osd", get(ai_osd).put(ai_osd_update))
         .route("/api/v1/ai/events", get(ai_events))
+        .route("/api/v1/ai/results/latest", get(ai_results_latest))
+        .route("/api/v1/ai/results/stream", get(ai_results_stream))
+        .route("/api/v1/ai/results/schema", get(ai_results_schema))
         .route("/api/v1/config", get(config).put(apply_config))
         .route("/api/v1/worker/start", post(start))
         .route("/api/v1/worker/stop", post(stop))
@@ -628,6 +631,9 @@ impl IntoResponse for ApiError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ai_results::{
+        AiBoundingBoxV1, AiFrameInfoV1, AiInferenceInfoV1, AiObjectV1, AiResultInput,
+    };
     use crate::config::{AiDaemonConfig, DaemonConfig, RtspConfig, WebRtcConfig};
     use crate::model::PersistentState;
     use crate::supervisor::spawn_supervisor;
@@ -635,6 +641,40 @@ mod tests {
     use http_body_util::BodyExt;
     use tempfile::tempdir;
     use tower::ServiceExt;
+
+    fn ai_result_input(sequence: u64) -> AiResultInput {
+        AiResultInput {
+            source_id: "camera0".into(),
+            media_generation: "media-test".into(),
+            ai_generation: "ai-test".into(),
+            sequence,
+            pts_us: sequence * 100_000,
+            published_at_ms: 1000 + sequence * 100,
+            frame: AiFrameInfoV1 {
+                width: 1920,
+                height: 1080,
+                coordinate_space: "main_normalized_top_left".into(),
+            },
+            inference: AiInferenceInfoV1 {
+                project: "test".into(),
+                algorithm: "yolov5".into(),
+                model: "test.rknn".into(),
+                duration_us: 100,
+            },
+            objects: vec![AiObjectV1 {
+                track_id: 1,
+                class_id: 0,
+                label: "person".into(),
+                confidence: 0.9,
+                bbox: AiBoundingBoxV1 {
+                    x: 0.1,
+                    y: 0.2,
+                    width: 0.3,
+                    height: 0.4,
+                },
+            }],
+        }
+    }
 
     #[test]
     fn parses_http_byte_ranges() {
@@ -718,7 +758,14 @@ mod tests {
         )
         .await
         .unwrap();
-        let app = router(handle.clone(), recording, rtsp, webrtc, ai, temp.path());
+        let app = router(
+            handle.clone(),
+            recording,
+            rtsp,
+            webrtc,
+            ai.clone(),
+            temp.path(),
+        );
         let response = app
             .clone()
             .oneshot(
@@ -734,6 +781,7 @@ mod tests {
         let mut invalid = WorkerConfig::default();
         invalid.video.width = 1;
         let response = app
+            .clone()
             .oneshot(
                 axum::http::Request::builder()
                     .method("PUT")
@@ -747,6 +795,86 @@ mod tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         let body = response.into_body().collect().await.unwrap().to_bytes();
         assert!(String::from_utf8_lossy(&body).contains("invalid_config"));
+
+        let latest = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/ai/results/latest")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(latest.status(), StatusCode::NO_CONTENT);
+
+        ai.publish_test_result(ai_result_input(1));
+        let latest = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/ai/results/latest")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(latest.status(), StatusCode::OK);
+        let latest_body = latest.into_body().collect().await.unwrap().to_bytes();
+        let latest_json: serde_json::Value = serde_json::from_slice(&latest_body).unwrap();
+        assert_eq!(latest_json["type"], "io.aipc.ai.frame.v1");
+        assert_eq!(latest_json["data"]["objects"][0]["bbox"]["x"], 0.1);
+        let latest_id = latest_json["id"].as_str().unwrap().to_owned();
+
+        let schema = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/ai/results/schema")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(schema.status(), StatusCode::OK);
+        assert_eq!(
+            schema.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/schema+json"
+        );
+        let schema_body = schema.into_body().collect().await.unwrap().to_bytes();
+        let schema_json: serde_json::Value = serde_json::from_slice(&schema_body).unwrap();
+        assert_eq!(schema_json["$id"], "/api/v1/ai/results/schema");
+
+        let stream_response = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/api/v1/ai/results/stream")
+                    .header("last-event-id", latest_id)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(stream_response.status(), StatusCode::OK);
+        assert!(
+            stream_response.headers()[header::CONTENT_TYPE]
+                .to_str()
+                .unwrap()
+                .starts_with("text/event-stream")
+        );
+        ai.publish_test_result(ai_result_input(2));
+        let mut stream_body = stream_response.into_body();
+        let frame = tokio::time::timeout(Duration::from_secs(1), stream_body.frame())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let data = frame.into_data().unwrap();
+        let text = String::from_utf8_lossy(&data);
+        assert!(text.contains("event: io.aipc.ai.frame.v1"));
+        assert!(text.contains("\"sequence\":2"));
+
         handle.shutdown().await;
     }
 }

--- a/aipc-daemon/src/api/ai.rs
+++ b/aipc-daemon/src/api/ai.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::ai_results::AiCloudEvent;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use tokio::sync::broadcast;
 
 pub(super) async fn ai_status(State(state): State<AppState>) -> impl IntoResponse {
     Json(state.ai.status())
@@ -141,4 +145,84 @@ pub(super) async fn ai_events(
             .interval(Duration::from_secs(10))
             .text("keep-alive"),
     )
+}
+
+pub(super) async fn ai_results_latest(State(state): State<AppState>) -> Response {
+    match state.ai.latest_result() {
+        Some(event) => Json((*event).clone()).into_response(),
+        None => StatusCode::NO_CONTENT.into_response(),
+    }
+}
+
+pub(super) async fn ai_results_schema() -> Response {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/schema+json")
+        .body(Body::from(AiManager::result_schema()))
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
+}
+
+struct AiResultStreamState {
+    ai: AiManager,
+    receiver: broadcast::Receiver<Arc<AiCloudEvent>>,
+    pending: VecDeque<Arc<AiCloudEvent>>,
+    last_sequence: u64,
+}
+
+pub(super) async fn ai_results_stream(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>> {
+    let cursor = headers
+        .get("last-event-id")
+        .and_then(|value| value.to_str().ok());
+    let subscription = state.ai.subscribe_results(cursor);
+    let stream = stream::unfold(
+        AiResultStreamState {
+            ai: state.ai,
+            receiver: subscription.receiver,
+            pending: subscription.pending,
+            last_sequence: subscription.last_sequence,
+        },
+        |mut state| async move {
+            loop {
+                if let Some(event) = state.pending.pop_front() {
+                    state.last_sequence = event.sequence().unwrap_or(state.last_sequence);
+                    return Some((Ok(cloud_event_sse(&event)), state));
+                }
+                match state.receiver.recv().await {
+                    Ok(event) => {
+                        let sequence = event.sequence().unwrap_or_default();
+                        if sequence <= state.last_sequence {
+                            continue;
+                        }
+                        state.last_sequence = sequence;
+                        return Some((Ok(cloud_event_sse(&event)), state));
+                    }
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        state.ai.record_result_lag(skipped);
+                        let (pending, cursor) = state.ai.replay_results_after(state.last_sequence);
+                        state.pending = pending;
+                        if state.pending.is_empty() {
+                            state.last_sequence = cursor;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return None,
+                }
+            }
+        },
+    );
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_secs(10))
+            .text("keep-alive"),
+    )
+}
+
+fn cloud_event_sse(event: &AiCloudEvent) -> Event {
+    Event::default()
+        .id(event.id.clone())
+        .event(event.event_type.clone())
+        .json_data(event)
+        .unwrap_or_else(|_| Event::default().event("serialization_error"))
 }

--- a/aipc-daemon/src/config.rs
+++ b/aipc-daemon/src/config.rs
@@ -333,6 +333,65 @@ impl WorkerConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
+pub struct UiConfig {
+    pub project_name: String,
+    pub console_name: String,
+    pub platform_name: String,
+    pub board_name: String,
+    pub project_url: String,
+    pub documentation_url: String,
+    pub visiong_url: String,
+    pub license_name: String,
+    pub license_url: String,
+}
+
+impl Default for UiConfig {
+    fn default() -> Self {
+        Self {
+            project_name: "AIPC".into(),
+            console_name: "Media Console".into(),
+            platform_name: "RV1106".into(),
+            board_name: "Luckfox Pico Ultra W".into(),
+            project_url: "https://github.com/haoyn231/aipc".into(),
+            documentation_url: "https://github.com/haoyn231/aipc/tree/main/docs".into(),
+            visiong_url: "https://github.com/yiex/visiong".into(),
+            license_name: "Apache-2.0".into(),
+            license_url: "https://github.com/haoyn231/aipc/blob/main/LICENSE".into(),
+        }
+    }
+}
+
+impl UiConfig {
+    fn validate(&self) -> anyhow::Result<()> {
+        for (name, value) in [
+            ("ui.project_name", &self.project_name),
+            ("ui.console_name", &self.console_name),
+            ("ui.platform_name", &self.platform_name),
+            ("ui.board_name", &self.board_name),
+            ("ui.license_name", &self.license_name),
+        ] {
+            anyhow::ensure!(
+                !value.trim().is_empty() && value.len() <= 128,
+                "{name} must contain 1-128 characters"
+            );
+        }
+        for (name, value) in [
+            ("ui.project_url", &self.project_url),
+            ("ui.documentation_url", &self.documentation_url),
+            ("ui.visiong_url", &self.visiong_url),
+            ("ui.license_url", &self.license_url),
+        ] {
+            anyhow::ensure!(
+                value.starts_with("https://") || value.starts_with("http://"),
+                "{name} must be an HTTP(S) URL"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct DaemonConfig {
     pub bind: String,
     pub worker_path: PathBuf,
@@ -345,6 +404,7 @@ pub struct DaemonConfig {
     pub stop_timeout_ms: u64,
     pub max_restarts: usize,
     pub restart_window_sec: u64,
+    pub ui: UiConfig,
     pub preview: PreviewConfig,
     pub recording: RecordingConfig,
     pub rtsp: RtspConfig,
@@ -560,6 +620,7 @@ impl Default for DaemonConfig {
             stop_timeout_ms: 5_000,
             max_restarts: 5,
             restart_window_sec: 300,
+            ui: UiConfig::default(),
             preview: PreviewConfig::default(),
             recording: RecordingConfig::default(),
             rtsp: RtspConfig::default(),
@@ -591,6 +652,7 @@ impl DaemonConfig {
             .map(|path| resolve(executable_dir, path))
             .collect();
         config.ai.validate()?;
+        config.ui.validate()?;
         config.webrtc.validate()?;
         Ok(config)
     }
@@ -660,6 +722,21 @@ mod tests {
         let config = AiDaemonConfig {
             result_replay_capacity: 0,
             ..AiDaemonConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validates_ui_platform_and_links() {
+        assert!(UiConfig::default().validate().is_ok());
+        let config = UiConfig {
+            platform_name: "".into(),
+            ..UiConfig::default()
+        };
+        assert!(config.validate().is_err());
+        let config = UiConfig {
+            project_url: "file:///tmp/aipc".into(),
+            ..UiConfig::default()
         };
         assert!(config.validate().is_err());
     }

--- a/aipc-daemon/src/config.rs
+++ b/aipc-daemon/src/config.rs
@@ -360,6 +360,11 @@ pub struct AiDaemonConfig {
     pub startup_timeout_ms: u64,
     pub max_model_bytes: u64,
     pub result_ttl_ms: u64,
+    pub source_id: String,
+    pub result_replay_capacity: usize,
+    pub track_confirmations: usize,
+    pub track_lost_timeout_ms: u64,
+    pub track_update_interval_ms: u64,
 }
 
 impl Default for AiDaemonConfig {
@@ -370,7 +375,42 @@ impl Default for AiDaemonConfig {
             startup_timeout_ms: 30_000,
             max_model_bytes: 128 * 1024 * 1024,
             result_ttl_ms: 500,
+            source_id: "camera0".into(),
+            result_replay_capacity: 256,
+            track_confirmations: 2,
+            track_lost_timeout_ms: 500,
+            track_update_interval_ms: 500,
         }
+    }
+}
+
+impl AiDaemonConfig {
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.source_id.is_empty()
+                && self.source_id.len() <= 64
+                && self.source_id.bytes().all(|byte| {
+                    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-')
+                }),
+            "ai.source_id must contain 1-64 safe identifier characters"
+        );
+        anyhow::ensure!(
+            (1..=4096).contains(&self.result_replay_capacity),
+            "ai.result_replay_capacity must be in [1, 4096]"
+        );
+        anyhow::ensure!(
+            (1..=16).contains(&self.track_confirmations),
+            "ai.track_confirmations must be in [1, 16]"
+        );
+        anyhow::ensure!(
+            (50..=60_000).contains(&self.track_lost_timeout_ms),
+            "ai.track_lost_timeout_ms must be in [50, 60000]"
+        );
+        anyhow::ensure!(
+            (50..=60_000).contains(&self.track_update_interval_ms),
+            "ai.track_update_interval_ms must be in [50, 60000]"
+        );
+        Ok(())
     }
 }
 
@@ -550,6 +590,7 @@ impl DaemonConfig {
             .iter()
             .map(|path| resolve(executable_dir, path))
             .collect();
+        config.ai.validate()?;
         config.webrtc.validate()?;
         Ok(config)
     }
@@ -605,6 +646,21 @@ mod tests {
         assert!(config.validate().is_err());
         config.max_clients = 1;
         config.advertised_ip = Some("0.0.0.0".parse().unwrap());
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validates_ai_result_settings() {
+        assert!(AiDaemonConfig::default().validate().is_ok());
+        let config = AiDaemonConfig {
+            source_id: "../camera".into(),
+            ..AiDaemonConfig::default()
+        };
+        assert!(config.validate().is_err());
+        let config = AiDaemonConfig {
+            result_replay_capacity: 0,
+            ..AiDaemonConfig::default()
+        };
         assert!(config.validate().is_err());
     }
 }

--- a/aipc-daemon/src/main.rs
+++ b/aipc-daemon/src/main.rs
@@ -1,5 +1,6 @@
 mod ai;
 mod ai_manager;
+mod ai_results;
 mod api;
 mod config;
 mod model;

--- a/aipc-daemon/src/main.rs
+++ b/aipc-daemon/src/main.rs
@@ -23,7 +23,7 @@ use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
 #[derive(Debug, Parser)]
-#[command(version, about = "RV1106 AIPC media worker supervisor")]
+#[command(version, about = "AIPC media worker supervisor")]
 struct Args {
     #[arg(long)]
     config: Option<PathBuf>,
@@ -120,6 +120,7 @@ async fn main() -> anyhow::Result<()> {
         rtsp.clone(),
         webrtc.clone(),
         ai.clone(),
+        settings.ui.clone(),
         &settings.web_dir,
     );
     let listener = TcpListener::bind(&settings.bind)

--- a/config/aipc-daemon.example.json
+++ b/config/aipc-daemon.example.json
@@ -48,6 +48,11 @@
     "worker_path": "ai_worker",
     "startup_timeout_ms": 30000,
     "max_model_bytes": 134217728,
-    "result_ttl_ms": 500
+    "result_ttl_ms": 500,
+    "source_id": "camera0",
+    "result_replay_capacity": 256,
+    "track_confirmations": 2,
+    "track_lost_timeout_ms": 500,
+    "track_update_interval_ms": 500
   }
 }

--- a/config/aipc-daemon.example.json
+++ b/config/aipc-daemon.example.json
@@ -10,6 +10,17 @@
   "stop_timeout_ms": 5000,
   "max_restarts": 5,
   "restart_window_sec": 300,
+  "ui": {
+    "project_name": "AIPC",
+    "console_name": "Media Console",
+    "platform_name": "RV1106",
+    "board_name": "Luckfox Pico Ultra W",
+    "project_url": "https://github.com/haoyn231/aipc",
+    "documentation_url": "https://github.com/haoyn231/aipc/tree/main/docs",
+    "visiong_url": "https://github.com/yiex/visiong",
+    "license_name": "Apache-2.0",
+    "license_url": "https://github.com/haoyn231/aipc/blob/main/LICENSE"
+  },
   "preview": {
     "enabled": true,
     "max_clients": 5,

--- a/docs/ai_result_api.md
+++ b/docs/ai_result_api.md
@@ -1,0 +1,192 @@
+# AIPC 标准 AI 结果接口 v1
+
+Rust daemon 将完成 AIPR 校验、模型输入坐标反变换和短生命周期目标跟踪后的结果，
+通过 HTTP JSON 与 SSE 提供给报警、记录和其他独立服务。公开事件采用 CloudEvents
+1.0 structured JSON；浏览器 OSD 使用的旧 `/api/v1/ai/events` 保持兼容，但新服务
+应使用本文的 `/api/v1/ai/results/*` 接口。
+
+## 接口
+
+| 方法 | 路径 | 用途 |
+| --- | --- | --- |
+| GET | `/api/v1/ai/results/latest` | 最新一条 `frame.v1`；尚无结果时返回 204 |
+| GET | `/api/v1/ai/results/stream` | CloudEvents SSE 实时流和有界补发 |
+| GET | `/api/v1/ai/results/schema` | `application/schema+json` 数据契约 |
+
+```bash
+curl -fsS http://BOARD_IP:8080/api/v1/ai/results/latest | jq
+curl -N http://BOARD_IP:8080/api/v1/ai/results/stream
+curl -fsS http://BOARD_IP:8080/api/v1/ai/results/schema | jq
+```
+
+daemon 当前沿用 trusted-LAN/no-auth 策略，不能直接暴露到不可信网络。
+
+## CloudEvents 与事件类型
+
+每个 SSE item 的 `id` 等于 CloudEvent `id`，`event` 等于 CloudEvent `type`，
+`data` 是完整 CloudEvent JSON：
+
+```text
+id: 1d63955e-5dbc-4454-88bb-9f5349b23535:42
+event: io.aipc.ai.frame.v1
+data: {"specversion":"1.0", ...}
+```
+
+支持的类型：
+
+- `io.aipc.ai.frame.v1`：每个通过校验的推理结果。
+- `io.aipc.ai.track.entered.v1`：同一 track 连续达到确认帧数。
+- `io.aipc.ai.track.updated.v1`：目标显著移动、置信度变化或达到更新心跳。
+- `io.aipc.ai.track.exited.v1`：目标超过丢失 TTL，或 AI generation 被停止/替换。
+- `io.aipc.ai.generation.v1`：media/AI generation 开始或停止。
+- `io.aipc.ai.stream.gap.v1`：请求的 cursor 已超出内存 replay 窗口。
+
+`id` 的冒号前是 daemon 实例 stream ID，冒号后是该实例内递增序号。daemon 重启后
+stream ID 会改变；消费者必须把新的 generation/gap 视为重新同步边界。track 的唯一
+身份是 `(ai_generation, track_id)`，不能只持久化 `track_id`。
+
+## frame.v1 数据
+
+```json
+{
+  "specversion": "1.0",
+  "id": "1d63955e-5dbc-4454-88bb-9f5349b23535:42",
+  "source": "urn:aipc:camera:camera0",
+  "type": "io.aipc.ai.frame.v1",
+  "subject": "frame/media-generation/1234",
+  "time": "2026-08-08T01:30:00Z",
+  "datacontenttype": "application/json",
+  "dataschema": "/api/v1/ai/results/schema",
+  "data": {
+    "schema_version": 1,
+    "source_id": "camera0",
+    "media_generation": "media-generation",
+    "ai_generation": "ai-generation",
+    "sequence": 1234,
+    "pts_us": 123456789,
+    "published_at_ms": 1786150000000,
+    "frame": {
+      "width": 1920,
+      "height": 1080,
+      "coordinate_space": "main_normalized_top_left"
+    },
+    "inference": {
+      "project": "yolov5-coco80",
+      "algorithm": "yolov5",
+      "model": "yolov5n_coco80_640.rknn",
+      "duration_us": 89000
+    },
+    "objects": [{
+      "track_id": 1,
+      "class_id": 62,
+      "label": "tv",
+      "confidence": 0.58,
+      "bbox": {"x": 0.42, "y": 0.31, "width": 0.16, "height": 0.28}
+    }]
+  }
+}
+```
+
+`bbox` 原点在主路图像左上角，全部值均为 `[0, 1]` 主路归一化坐标；消费者可用
+`frame.width/height` 换算像素。`pts_us` 是媒体链路单调微秒时间戳，用于和视频帧、
+录像 generation 对齐；CloudEvent `time` 和 `published_at_ms` 是 daemon 发布墙上时间，
+适合日志排序，但不能替代精确媒体 PTS。
+
+## SSE 补发和 gap
+
+daemon 默认在内存中保留最近 256 个事件。SSE 客户端应保存最后成功处理的 `id`，
+重连时发送标准 `Last-Event-ID`：
+
+```bash
+curl -N -H 'Last-Event-ID: STREAM_UUID:42' \
+  http://BOARD_IP:8080/api/v1/ai/results/stream
+```
+
+- cursor 仍在窗口内：先顺序补发 cursor 之后的事件，再转入实时流。
+- cursor 的 stream ID 不匹配或已过期：先收到 `stream.gap.v1`，其中包含当前
+  `earliest_event_id` 和 `latest_event_id`。
+- 收到 gap 后：调用 `results/latest` 建立最新状态，并以随后 SSE 事件继续处理。
+
+replay 只存在内存中，不保证 daemon 重启后的审计级重放。慢消费者不会反压 AI、
+OSD 或 VENC；如果内部 broadcast 落后，daemon 优先从 replay ring 补齐，超出窗口后
+明确发送 gap。
+
+## Python 消费者示例
+
+```python
+import json
+import requests
+
+url = "http://BOARD_IP:8080/api/v1/ai/results/stream"
+last_event_id = None
+
+while True:
+    headers = {"Accept": "text/event-stream"}
+    if last_event_id:
+        headers["Last-Event-ID"] = last_event_id
+    with requests.get(url, headers=headers, stream=True, timeout=(5, None)) as response:
+        response.raise_for_status()
+        event_id = None
+        for raw in response.iter_lines(decode_unicode=True):
+            if raw.startswith("id:"):
+                event_id = raw[3:].strip()
+            elif raw.startswith("data:"):
+                event = json.loads(raw[5:].strip())
+                if event["type"] == "io.aipc.ai.track.entered.v1":
+                    obj = event["data"]["object"]
+                    print("alarm candidate", obj["label"], obj["confidence"])
+                elif event["type"] == "io.aipc.ai.stream.gap.v1":
+                    latest = requests.get(
+                        "http://BOARD_IP:8080/api/v1/ai/results/latest", timeout=5
+                    )
+                    if latest.status_code == 200:
+                        print("resync", latest.json())
+                if event_id:
+                    last_event_id = event_id
+```
+
+生产消费者应在业务处理成功后再持久化 `last_event_id`。报警规则通常订阅
+`track.entered/exited` 并自行增加区域、时间段和去抖规则；记录服务可保存
+`frame.v1` 的 `media_generation + pts_us`，或在满足条件时调用现有录像 API。
+
+## Rust 消费者示例
+
+下面示例使用 `reqwest-eventsource`；生产代码同样应在业务处理成功后保存 event ID：
+
+```rust
+use futures_util::StreamExt;
+use reqwest_eventsource::{Event, EventSource};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let request = reqwest::Client::new()
+        .get("http://BOARD_IP:8080/api/v1/ai/results/stream");
+    let mut stream = EventSource::new(request)?;
+    while let Some(item) = stream.next().await {
+        if let Event::Message(message) = item? {
+            let event: serde_json::Value = serde_json::from_str(&message.data)?;
+            if event["type"] == "io.aipc.ai.track.entered.v1" {
+                println!("entered: {}", event["data"]["object"]);
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+## 配置与状态
+
+`ai` 配置新增：
+
+```json
+{
+  "source_id": "camera0",
+  "result_replay_capacity": 256,
+  "track_confirmations": 2,
+  "track_lost_timeout_ms": 500,
+  "track_update_interval_ms": 500
+}
+```
+
+`GET /api/v1/ai/status` 的 `result_bus` 提供 stream ID、最新/最早事件 ID、累计发布数、
+replay 深度/容量和消费者 lag 计数。以上配置缺失时使用默认值，旧配置文件无需迁移。

--- a/docs/ai_worker_lua_architecture.md
+++ b/docs/ai_worker_lua_architecture.md
@@ -324,10 +324,15 @@ RGA 或 NPU 同步路径，因此 WebRTC、RTSP 和 MP4 都包含框，主路保
 - `GET /api/v1/ai/osd`
 - `PUT /api/v1/ai/osd`，body 为 `{ "mode": "..." }`
 - `GET /api/v1/ai/events`，SSE metadata fallback
+- `GET /api/v1/ai/results/latest`，最新标准 CloudEvent
+- `GET /api/v1/ai/results/stream`，支持 `Last-Event-ID` 的 SSE/replay
+- `GET /api/v1/ai/results/schema`，AI 结果 JSON Schema
 
 AI status 至少返回 enabled/state、active/last-good project、generation、active input、
 worker PID、ready、last result time、inference FPS/latency、media/daemon/AI drop 计数、
-RGN capability 和 last error。删除活动或 last-good 引用的模型必须返回冲突。
+RGN capability、标准结果总线状态和 last error。删除活动或 last-good 引用的模型必须
+返回冲突。外部服务接口的 CloudEvents、坐标和 replay 契约见
+[`ai_result_api.md`](./ai_result_api.md)。
 
 Web UI 提供 AI 状态、项目列表、Lua/manifest 编辑、校验、部署、模型上传/删除、
 推理指标、错误和 OSD 三态控制。文件先写 `.part` 并 fsync/rename，失败不得覆盖

--- a/webui/src/AboutView.vue
+++ b/webui/src/AboutView.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { AboutInfo } from './types'
+
+const props = defineProps<{ info: AboutInfo | null }>()
+
+const links = computed(() => props.info ? [
+  { label: '项目源码', description: 'AIPC GitHub 仓库、Issue 和版本历史', url: props.info.project_url },
+  { label: '架构文档', description: '进程边界、构建、部署和 AI 协议说明', url: props.info.documentation_url },
+  { label: 'VisionG', description: '当前 RKNN 推理后端使用的 C++ 视觉库', url: props.info.visiong_url },
+  { label: props.info.license_name, description: 'AIPC 项目的开源许可证', url: props.info.license_url },
+] : [])
+</script>
+
+<template>
+  <div class="about-page">
+    <section class="panel about-hero">
+      <div>
+        <span class="label">ABOUT {{ info?.project_name || 'AIPC' }}</span>
+        <h3>面向边缘设备的音视频与 AI 控制平面</h3>
+        <p>AIPC 将实时媒体链路、AI 推理和 Web 管理拆成相互隔离的进程。主视频连续性优先，AI 可以独立降帧、重启或切换模型，而不会进入 VENC 的同步关键路径。</p>
+      </div>
+      <div class="about-badge">
+        <span>{{ info?.project_name || 'AIPC' }}</span>
+        <strong>v{{ info?.daemon_version || '—' }}</strong>
+        <small>{{ info?.console_name || 'Media Console' }}</small>
+      </div>
+    </section>
+
+    <section class="about-grid">
+      <article class="panel about-platform">
+        <div class="section-head"><div><span class="label">CURRENT TARGET</span><h3>当前运行平台</h3><p>平台标识由 daemon 配置文件提供，后续适配其他 SoC 时无需修改 Web 源码。</p></div></div>
+        <dl>
+          <div><dt>Platform</dt><dd>{{ info?.platform_name || '—' }}</dd></div>
+          <div><dt>Board</dt><dd>{{ info?.board_name || '—' }}</dd></div>
+          <div><dt>Daemon</dt><dd>{{ info?.daemon_version || '—' }}</dd></div>
+          <div><dt>Security</dt><dd>Trusted LAN / No Auth</dd></div>
+        </dl>
+      </article>
+
+      <article class="panel about-architecture">
+        <div class="section-head"><div><span class="label">PROCESS MODEL</span><h3>三进程架构</h3></div></div>
+        <div class="process-flow">
+          <div><b>aipc-daemon</b><span>Rust · API / Web / supervisor</span></div>
+          <i>→</i>
+          <div><b>media_worker</b><span>C++ · ISP / VPSS / VENC</span></div>
+          <i>+</i>
+          <div><b>ai_worker</b><span>C++ / Lua · RKNN inference</span></div>
+        </div>
+      </article>
+    </section>
+
+    <section class="panel about-capabilities">
+      <div class="section-head"><div><span class="label">CAPABILITIES</span><h3>当前能力</h3></div></div>
+      <div class="capability-grid">
+        <div><b>实时媒体</b><p>H.264、G711A、WebRTC、RTSP 和 MP4 录像。</p></div>
+        <div><b>Lua 管理 AI</b><p>动态 VPSS 输入、VisionG/RKNN 模型和 last-good 回滚。</p></div>
+        <div><b>标准结果接口</b><p>CloudEvents 1.0、HTTP latest、SSE replay 和目标生命周期。</p></div>
+        <div><b>非阻塞 OSD</b><p>浏览器 metadata 或硬件 RGN，不让 NPU 延迟阻塞主码流。</p></div>
+      </div>
+    </section>
+
+    <section class="panel about-links">
+      <div class="section-head"><div><span class="label">PROJECT LINKS</span><h3>项目与依赖</h3><p>以下地址同样来自 daemon 配置，可以针对私有部署或镜像仓库覆盖。</p></div></div>
+      <div class="link-grid">
+        <a v-for="link in links" :key="link.label" :href="link.url" target="_blank" rel="noreferrer">
+          <span>{{ link.label }}</span><b>↗</b><small>{{ link.description }}</small>
+        </a>
+      </div>
+    </section>
+  </div>
+</template>

--- a/webui/src/AiView.vue
+++ b/webui/src/AiView.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
-import { api } from './api'
-import type { AiModelInfo, AiOsdMode, AiProjectDocument, AiProjectSummary, AiStatus } from './types'
+import { api, connectAiResultEvents } from './api'
+import { aiResultCategory, aiResultMatches, aiResultSummary, aiResultTypeLabel, appendAiResultEvents, shortEventId } from './aiResults'
+import type { AiResultFilter } from './aiResults'
+import type { AiCloudEvent, AiModelInfo, AiOsdMode, AiProjectDocument, AiProjectSummary, AiStatus } from './types'
 
 const status = ref<AiStatus | null>(null)
 const projects = ref<AiProjectSummary[]>([])
@@ -12,9 +14,18 @@ const busy = ref(false)
 const notice = ref('')
 const error = ref('')
 const upload = ref<HTMLInputElement | null>(null)
+const resultEvents = ref<AiCloudEvent[]>([])
+const resultFilter = ref<AiResultFilter>('all')
+const resultConnected = ref(false)
+const resultPaused = ref(false)
+const resultSkipped = ref(0)
+const pendingResultEvents: AiCloudEvent[] = []
 let timer = 0
+let resultTimer = 0
+let disconnectResults: (() => void) | null = null
 
 const selected = computed(() => projects.value.find((project) => project.id === selectedId.value))
+const visibleResultEvents = computed(() => resultEvents.value.filter((event) => aiResultMatches(event, resultFilter.value)))
 
 async function refresh() {
   try {
@@ -134,11 +145,51 @@ async function action(operation: () => Promise<void>) {
   try { await operation() } catch (cause) { error.value = String(cause) } finally { busy.value = false }
 }
 
+function enqueueResult(event: AiCloudEvent) {
+  if (resultPaused.value) {
+    resultSkipped.value += 1
+    return
+  }
+  pendingResultEvents.push(event)
+}
+
+function flushResultEvents() {
+  if (!pendingResultEvents.length) return
+  resultEvents.value = appendAiResultEvents(resultEvents.value, pendingResultEvents.splice(0))
+}
+
+async function toggleResultPause() {
+  resultPaused.value = !resultPaused.value
+  if (!resultPaused.value) {
+    const latest = await api.aiResultLatest().catch(() => null)
+    if (latest) enqueueResult(latest)
+    flushResultEvents()
+  }
+}
+
+function clearResultEvents() {
+  pendingResultEvents.splice(0)
+  resultEvents.value = []
+  resultSkipped.value = 0
+}
+
+function eventTime(event: AiCloudEvent) {
+  const time = new Date(event.time)
+  return Number.isNaN(time.getTime()) ? event.time : time.toLocaleTimeString()
+}
+
 onMounted(() => {
   void refresh()
   timer = window.setInterval(() => { void api.aiStatus().then((value) => { status.value = value }).catch(() => undefined) }, 2000)
+  resultTimer = window.setInterval(flushResultEvents, 120)
+  void api.aiResultLatest().then((event) => { if (event) enqueueResult(event) }).catch(() => undefined)
+  disconnectResults = connectAiResultEvents(enqueueResult, (connected) => { resultConnected.value = connected })
 })
-onBeforeUnmount(() => window.clearInterval(timer))
+onBeforeUnmount(() => {
+  window.clearInterval(timer)
+  window.clearInterval(resultTimer)
+  disconnectResults?.()
+})
 </script>
 
 <template>
@@ -179,6 +230,43 @@ onBeforeUnmount(() => window.clearInterval(timer))
       <div class="section-head"><div><span class="label">RKNN MODELS</span><h3>模型与标签</h3><p>上传使用临时文件和原子 rename；活动或 last-good 项目引用的文件不可删除。</p></div><div class="model-upload"><input ref="upload" type="file" accept=".rknn,.txt"><button class="accent" :disabled="busy" @click="uploadModel">上传</button></div></div>
       <div class="model-row model-header"><span>文件</span><span>大小</span><span>SHA-256</span><span>状态</span><span></span></div>
       <div v-for="model in models" :key="model.name" class="model-row"><b>{{ model.name }}</b><span>{{ (model.bytes / 1024 / 1024).toFixed(2) }} MiB</span><code>{{ model.sha256 }}</code><span>{{ model.active ? 'IN USE' : 'AVAILABLE' }}</span><button class="secondary compact" :disabled="model.active || busy" @click="removeModel(model)">删除</button></div>
+    </section>
+
+    <section class="panel ai-results-panel">
+      <div class="section-head event-head">
+        <div><span class="label">STANDARD AI EVENTS</span><h3>结构化识别事件</h3><p>CloudEvents 1.0 实时结果；展开事件可查看完整标准 JSON，适用于报警和记录服务联调。</p></div>
+        <div class="section-actions result-actions">
+          <span :class="['result-connection', resultConnected && 'online']"><i></i>{{ resultConnected ? 'LIVE' : 'RECONNECTING' }}</span>
+          <button class="secondary compact" :class="resultPaused && 'selected'" @click="toggleResultPause">{{ resultPaused ? '继续' : '暂停' }}</button>
+          <button class="secondary compact" @click="clearResultEvents">清空</button>
+        </div>
+      </div>
+      <div class="result-bus-grid">
+        <div><span>Stream</span><b>{{ status?.result_bus.stream_id.slice(0, 8) || '—' }}</b></div>
+        <div><span>Latest</span><b>{{ shortEventId(status?.result_bus.latest_event_id) }}</b></div>
+        <div><span>Replay</span><b>{{ status?.result_bus.replay_depth || 0 }} / {{ status?.result_bus.replay_capacity || 0 }}</b></div>
+        <div><span>Published</span><b>{{ status?.result_bus.published || 0 }}</b></div>
+        <div><span>Subscriber lag</span><b>{{ status?.result_bus.lagged_events || 0 }}</b></div>
+      </div>
+      <div class="result-toolbar">
+        <label>事件类型<select v-model="resultFilter"><option value="all">全部事件</option><option value="frame">逐帧结果</option><option value="tracks">目标生命周期</option><option value="generation">Generation</option><option value="gap">Replay gap</option></select></label>
+        <span>{{ visibleResultEvents.length }} / {{ resultEvents.length }} events</span>
+        <span v-if="resultSkipped">暂停期间跳过 {{ resultSkipped }}</span>
+        <a href="/api/v1/ai/results/schema" target="_blank" rel="noreferrer">查看 JSON Schema ↗</a>
+      </div>
+      <div class="ai-result-events">
+        <details v-for="event in visibleResultEvents" :key="event.id" :class="['ai-result-row', `result-${aiResultCategory(event)}`, event.type.includes('.exited.') && 'result-exited']">
+          <summary>
+            <time>{{ eventTime(event) }}</time>
+            <span class="result-type">{{ aiResultTypeLabel(event.type) }}</span>
+            <b>{{ event.subject }}</b>
+            <span class="result-summary">{{ aiResultSummary(event) }}</span>
+            <code>{{ shortEventId(event.id) }}</code>
+          </summary>
+          <pre>{{ JSON.stringify(event, null, 2) }}</pre>
+        </details>
+        <p v-if="!visibleResultEvents.length" class="empty-state">等待标准化 AI 事件…</p>
+      </div>
     </section>
   </div>
 </template>

--- a/webui/src/App.vue
+++ b/webui/src/App.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { api, connectEvents, reduceServerEvent, type LiveState } from './api'
-import type { PersistentState, WorkerConfig } from './types'
+import type { AboutInfo, PersistentState, WorkerConfig } from './types'
 import { initialPreviewSnapshot } from './preview'
 import { AdaptivePreviewController } from './webrtcPreview'
 import { AiOverlayController } from './aiOverlay'
 import AiView from './AiView.vue'
+import AboutView from './AboutView.vue'
 import RecordingsView from './RecordingsView.vue'
 import {
   currentBitrate, currentVideoFps, eventLevel, eventName, eventSummary, matchesEventFilter,
@@ -14,6 +15,7 @@ import {
 } from './telemetry'
 
 const live = reactive<LiveState>({ status: null, events: [], logs: [] })
+const about = ref<AboutInfo | null>(null)
 const configs = ref<PersistentState | null>(null)
 const form = ref<WorkerConfig | null>(null)
 const connected = ref(false)
@@ -31,7 +33,8 @@ const eventViewport = ref<HTMLDivElement | null>(null)
 const eventFilter = ref<EventFilter>('all')
 const eventFilters: EventFilter[] = ['all', 'info', 'warn', 'error']
 const eventFollow = ref(true)
-const activeView = ref<'overview' | 'recordings' | 'ai' | 'settings' | 'diagnostics'>('overview')
+type AppView = 'overview' | 'recordings' | 'ai' | 'settings' | 'diagnostics' | 'about'
+const activeView = ref<AppView>('overview')
 const clockMs = ref(Date.now())
 const statusReceivedAtMs = ref(Date.now())
 let previewController: AdaptivePreviewController | undefined
@@ -39,6 +42,15 @@ let aiOverlay: AiOverlayController | undefined
 let clockTimer: number | undefined
 
 const status = computed(() => live.status)
+const viewMetadata: Record<AppView, { eyebrow: string; title: string }> = {
+  overview: { eyebrow: 'OVERVIEW', title: '运行概览' },
+  recordings: { eyebrow: 'RECORDINGS', title: '录像管理' },
+  ai: { eyebrow: 'AI WORKER', title: 'AI 与 Lua 管理' },
+  settings: { eyebrow: 'CONFIGURATION', title: '媒体配置' },
+  diagnostics: { eyebrow: 'DIAGNOSTICS', title: '日志诊断' },
+  about: { eyebrow: 'ABOUT', title: '关于 AIPC' },
+}
+const activeViewMetadata = computed(() => viewMetadata[activeView.value])
 const metrics = computed(() => status.value?.metrics)
 const videoMetrics = computed(() => metrics.value?.video)
 const audioMetrics = computed(() => metrics.value?.audio)
@@ -82,8 +94,10 @@ async function refreshConfig() {
 
 async function load() {
   try {
-    const [nextStatus, nextConfig, nextLogs] = await Promise.all([api.status(), api.config(), api.logs(100)])
+    const [nextStatus, nextConfig, nextLogs, nextAbout] = await Promise.all([api.status(), api.config(), api.logs(100), api.about()])
     live.status = nextStatus; live.logs = nextLogs; configs.value = nextConfig
+    about.value = nextAbout
+    document.title = `${nextAbout.project_name} ${nextAbout.console_name}`
     form.value = structuredClone(nextConfig.desired || nextConfig.last_good)
   } catch (cause) { error.value = String(cause) }
 }
@@ -181,13 +195,14 @@ onBeforeUnmount(() => { disconnect?.(); previewController?.destroy(); aiOverlay?
 <template>
   <div class="app-shell">
     <aside class="sidebar">
-      <div class="brand"><span class="brand-mark">AI</span><div><p class="eyebrow">RV1106 CONTROL</p><h1>Media Console</h1></div></div>
+      <div class="brand"><span class="brand-mark">AI</span><div><p class="eyebrow">{{ about?.platform_name || 'AIPC' }} CONTROL</p><h1>{{ about?.console_name || 'Media Console' }}</h1></div></div>
       <nav class="nav-tabs" aria-label="主导航">
         <button :class="activeView === 'overview' && 'active'" @click="activeView = 'overview'"><span>01</span>运行概览</button>
         <button :class="activeView === 'recordings' && 'active'" @click="activeView = 'recordings'"><span>02</span>录像管理</button>
         <button :class="activeView === 'ai' && 'active'" @click="activeView = 'ai'"><span>03</span>AI 与 Lua</button>
         <button :class="activeView === 'settings' && 'active'" @click="activeView = 'settings'"><span>04</span>媒体配置</button>
         <button :class="activeView === 'diagnostics' && 'active'" @click="activeView = 'diagnostics'"><span>05</span>日志诊断<i v-if="live.events.some(event => eventLevel(event) === 'error')"></i></button>
+        <button :class="activeView === 'about' && 'active'" @click="activeView = 'about'"><span>06</span>关于</button>
       </nav>
       <div class="sidebar-meta">
         <div class="connection"><span :class="['dot', connected && 'online']"></span><div><b>{{ connected ? '服务已连接' : '正在重连' }}</b><small>SSE EVENT STREAM</small></div></div>
@@ -197,7 +212,7 @@ onBeforeUnmount(() => { disconnect?.(); previewController?.destroy(); aiOverlay?
 
     <main>
       <header class="topbar">
-        <div><p class="eyebrow">{{ activeView === 'overview' ? 'OVERVIEW' : activeView === 'recordings' ? 'RECORDINGS' : activeView === 'ai' ? 'AI WORKER' : activeView === 'settings' ? 'CONFIGURATION' : 'DIAGNOSTICS' }}</p><h2>{{ activeView === 'overview' ? '运行概览' : activeView === 'recordings' ? '录像管理' : activeView === 'ai' ? 'AI 与 Lua 管理' : activeView === 'settings' ? '媒体配置' : '日志诊断' }}</h2></div>
+        <div><p class="eyebrow">{{ activeViewMetadata.eyebrow }}</p><h2>{{ activeViewMetadata.title }}</h2></div>
         <div class="header-status"><span :class="['status-pill', status?.state]">{{ status?.state || 'offline' }}</span><span>运行 {{ uptime }}</span></div>
       </header>
 
@@ -246,12 +261,14 @@ onBeforeUnmount(() => { disconnect?.(); previewController?.destroy(); aiOverlay?
         <section class="panel config-versions"><div class="section-head"><div><span class="label">CONFIG HISTORY</span><h3>配置版本</h3><p>用于核对当前生效、待应用与最近可用配置。</p></div></div><div class="config-stack"><details v-for="row in configDiff" :key="row.name"><summary><b>{{ row.name }}</b><span>{{ short(row.value?.runtime.generation) }}</span></summary><pre>{{ JSON.stringify(row.value, null, 2) }}</pre></details></div><p v-if="configs?.last_error" class="rollback">最近回滚 / 错误：{{ configs.last_error }}</p></section>
       </template>
 
-      <template v-else>
+      <template v-else-if="activeView === 'diagnostics'">
         <section class="diagnostic-grid">
           <article class="panel terminal"><div class="section-head"><div><span class="label">WORKER STDERR</span><h3>运行日志</h3></div><span class="count">{{ live.logs.length }} / 200</span></div><div class="log-lines"><p v-for="(line, i) in live.logs.slice(-100)" :key="i"><time>{{ new Date(line.timestamp_ms).toLocaleTimeString() }}</time> {{ line.line }}</p><p v-if="!live.logs.length" class="empty-state">暂无 stderr 输出</p></div></article>
           <article class="panel events"><div class="section-head event-head"><div><span class="label">EVENT STREAM</span><h3>结构化事件</h3><p>{{ filteredEvents.length }} 条匹配事件</p></div><div class="event-tools"><div class="event-filters"><button v-for="filter in eventFilters" :key="filter" class="secondary compact" :class="eventFilter === filter && 'selected'" @click="eventFilter = filter">{{ filter }}</button></div><button v-if="!eventFollow" class="secondary compact" @click="resumeEventFollow">继续跟随</button><button class="secondary compact" @click="clearEvents">清空</button></div></div><div ref="eventViewport" class="event-lines" @scroll="handleEventScroll"><details v-for="(event, index) in filteredEvents" :key="`${event.timestamp_ms}-${event.kind}-${index}`" :class="['event-row', `event-${eventLevel(event)}`]"><summary><time>{{ new Date(event.timestamp_ms).toLocaleTimeString() }}</time><span class="event-level">{{ eventLevel(event) }}</span><b>{{ eventName(event) }}</b><span class="event-summary">{{ eventSummary(event) }}</span></summary><pre>{{ JSON.stringify(event.payload, null, 2) }}</pre></details><p v-if="!filteredEvents.length" class="empty-state">当前过滤条件下暂无事件</p></div></article>
         </section>
       </template>
+
+      <AboutView v-else-if="activeView === 'about'" :info="about" />
     </main>
   </div>
 </template>

--- a/webui/src/aiResults.test.ts
+++ b/webui/src/aiResults.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { aiResultCategory, aiResultMatches, aiResultSummary, appendAiResultEvents, shortEventId } from './aiResults'
+import type { AiCloudEvent, AiResultEventType } from './types'
+
+function event(id: string, type: AiResultEventType = 'io.aipc.ai.frame.v1'): AiCloudEvent {
+  return {
+    specversion: '1.0',
+    id: `stream-uuid:${id}`,
+    source: 'urn:aipc:camera:camera0',
+    type,
+    subject: type.includes('.track.') ? 'track/ai-1/7' : 'frame/media-1/42',
+    time: '2026-08-08T01:30:00Z',
+    datacontenttype: 'application/json',
+    dataschema: '/api/v1/ai/results/schema',
+    data: type === 'io.aipc.ai.frame.v1' ? {
+      schema_version: 1,
+      source_id: 'camera0',
+      media_generation: 'media-1',
+      ai_generation: 'ai-1',
+      sequence: 42,
+      pts_us: 123456,
+      published_at_ms: 1,
+      frame: { width: 1920, height: 1080, coordinate_space: 'main_normalized_top_left' },
+      inference: { project: 'yolo', algorithm: 'yolov5', model: 'model.rknn', duration_us: 89000 },
+      objects: [{
+        track_id: 7,
+        class_id: 0,
+        label: 'person',
+        confidence: 0.91,
+        bbox: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+      }],
+    } : {
+      schema_version: 1,
+      source_id: 'camera0',
+      media_generation: 'media-1',
+      ai_generation: 'ai-1',
+      sequence: 42,
+      pts_us: 123456,
+      published_at_ms: 1,
+      frame: { width: 1920, height: 1080, coordinate_space: 'main_normalized_top_left' },
+      inference: { project: 'yolo', algorithm: 'yolov5', model: 'model.rknn', duration_us: 89000 },
+      object: {
+        track_id: 7,
+        class_id: 0,
+        label: 'person',
+        confidence: 0.91,
+        bbox: { x: 0.1, y: 0.2, width: 0.3, height: 0.4 },
+      },
+      reason: 'confirmed',
+    },
+  }
+}
+
+describe('AI standard result viewer helpers', () => {
+  it('deduplicates events and keeps newest events first within the bound', () => {
+    const result = appendAiResultEvents([event('1'), event('4')], [event('3'), event('1'), event('2'), event('2')], 3)
+    expect(result.map((item) => item.id)).toEqual(['stream-uuid:4', 'stream-uuid:3', 'stream-uuid:2'])
+  })
+
+  it('classifies and filters target lifecycle events', () => {
+    const entered = event('9', 'io.aipc.ai.track.entered.v1')
+    expect(aiResultCategory(entered)).toBe('tracks')
+    expect(aiResultMatches(entered, 'tracks')).toBe(true)
+    expect(aiResultMatches(entered, 'frame')).toBe(false)
+    expect(aiResultSummary(entered)).toContain('track 7 · person 91.0%')
+  })
+
+  it('summarizes frame objects and shortens stream event IDs', () => {
+    const frame = event('42')
+    expect(aiResultSummary(frame)).toContain('frame 42 · 1 objects · person 91%')
+    expect(shortEventId(frame.id)).toBe('stream-u:42')
+  })
+})

--- a/webui/src/aiResults.ts
+++ b/webui/src/aiResults.ts
@@ -1,0 +1,80 @@
+import type { AiCloudEvent, AiFrameResultData, AiResultEventType, AiTrackResultData } from './types'
+
+export type AiResultFilter = 'all' | 'frame' | 'tracks' | 'generation' | 'gap'
+export type AiResultCategory = Exclude<AiResultFilter, 'all'>
+
+export const aiResultEventTypes: AiResultEventType[] = [
+  'io.aipc.ai.frame.v1',
+  'io.aipc.ai.track.entered.v1',
+  'io.aipc.ai.track.updated.v1',
+  'io.aipc.ai.track.exited.v1',
+  'io.aipc.ai.stream.gap.v1',
+  'io.aipc.ai.generation.v1',
+]
+
+export function aiResultCategory(event: AiCloudEvent): AiResultCategory {
+  if (event.type === 'io.aipc.ai.frame.v1') return 'frame'
+  if (event.type.startsWith('io.aipc.ai.track.')) return 'tracks'
+  if (event.type === 'io.aipc.ai.generation.v1') return 'generation'
+  return 'gap'
+}
+
+export function aiResultTypeLabel(type: AiResultEventType): string {
+  return type.replace('io.aipc.ai.', '').replace('.v1', '')
+}
+
+export function aiResultMatches(event: AiCloudEvent, filter: AiResultFilter): boolean {
+  return filter === 'all' || aiResultCategory(event) === filter
+}
+
+export function appendAiResultEvents(
+  current: AiCloudEvent[],
+  incoming: AiCloudEvent[],
+  limit = 240,
+): AiCloudEvent[] {
+  const known = new Set(current.map((event) => event.id))
+  const unique = incoming.filter((event) => {
+    if (known.has(event.id)) return false
+    known.add(event.id)
+    return true
+  })
+  if (!unique.length) return current
+  return [...unique, ...current].sort(compareNewestFirst).slice(0, limit)
+}
+
+function compareNewestFirst(left: AiCloudEvent, right: AiCloudEvent): number {
+  const leftSeparator = left.id.lastIndexOf(':')
+  const rightSeparator = right.id.lastIndexOf(':')
+  const leftStream = left.id.slice(0, leftSeparator)
+  const rightStream = right.id.slice(0, rightSeparator)
+  if (leftSeparator >= 0 && rightSeparator >= 0 && leftStream === rightStream) {
+    const leftSequence = Number(left.id.slice(leftSeparator + 1))
+    const rightSequence = Number(right.id.slice(rightSeparator + 1))
+    if (Number.isFinite(leftSequence) && Number.isFinite(rightSequence)) return rightSequence - leftSequence
+  }
+  return Date.parse(right.time) - Date.parse(left.time)
+}
+
+export function aiResultSummary(event: AiCloudEvent): string {
+  if (event.type === 'io.aipc.ai.frame.v1') {
+    const data = event.data as AiFrameResultData
+    const labels = data.objects.slice(0, 4).map((object) => `${object.label} ${(object.confidence * 100).toFixed(0)}%`)
+    return `frame ${data.sequence} · ${data.objects.length} objects${labels.length ? ` · ${labels.join(', ')}` : ''}`
+  }
+  if (event.type.startsWith('io.aipc.ai.track.')) {
+    const data = event.data as AiTrackResultData
+    return `track ${data.object.track_id} · ${data.object.label} ${(data.object.confidence * 100).toFixed(1)}% · ${data.reason}`
+  }
+  if (event.type === 'io.aipc.ai.generation.v1') {
+    const data = event.data as { state: string; reason: string; ai_generation: string | null }
+    return `${data.state} · ${data.ai_generation?.slice(0, 8) || 'none'} · ${data.reason}`
+  }
+  const data = event.data as { reason: string; earliest_event_id: string | null; latest_event_id: string | null }
+  return `${data.reason} · replay ${shortEventId(data.earliest_event_id)} → ${shortEventId(data.latest_event_id)}`
+}
+
+export function shortEventId(id: string | null | undefined): string {
+  if (!id) return '—'
+  const separator = id.lastIndexOf(':')
+  return separator < 0 ? id : `${id.slice(0, 8)}:${id.slice(separator + 1)}`
+}

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -1,4 +1,5 @@
-import type { AiModelInfo, AiOsdMode, AiProjectDocument, AiProjectSummary, AiStatus, DaemonStatus, LogEntry, PersistentState, RecordingList, RecordingSettings, RecordingStatus, RtspStatus, ServerEvent, WorkerConfig } from './types'
+import { aiResultEventTypes } from './aiResults'
+import type { AiCloudEvent, AiModelInfo, AiOsdMode, AiProjectDocument, AiProjectSummary, AiStatus, DaemonStatus, LogEntry, PersistentState, RecordingList, RecordingSettings, RecordingStatus, RtspStatus, ServerEvent, WorkerConfig } from './types'
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(path, init)
@@ -65,6 +66,13 @@ export const api = {
   setAiOsd: (mode: AiOsdMode) => request<{ mode: AiOsdMode }>('/api/v1/ai/osd', {
     method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ mode }),
   }),
+  aiResultLatest: async (): Promise<AiCloudEvent | null> => {
+    const response = await fetch('/api/v1/ai/results/latest')
+    if (response.status === 204) return null
+    const body = await response.json().catch(() => ({}))
+    if (!response.ok) throw new Error(body?.error?.message || `HTTP ${response.status}`)
+    return body as AiCloudEvent
+  },
 }
 
 export interface LiveState {
@@ -88,6 +96,24 @@ export function connectEvents(onEvent: (event: ServerEvent) => void, onConnectio
       try {
         const parsed = JSON.parse((message as MessageEvent).data)
         onEvent(parsed?.kind ? parsed : { kind, timestamp_ms: Date.now(), payload: parsed })
+      } catch { /* keep stream alive */ }
+    })
+  }
+  source.onopen = () => onConnection(true)
+  source.onerror = () => onConnection(false)
+  return () => source.close()
+}
+
+export function connectAiResultEvents(
+  onEvent: (event: AiCloudEvent) => void,
+  onConnection: (up: boolean) => void,
+) {
+  const source = new EventSource('/api/v1/ai/results/stream')
+  for (const kind of aiResultEventTypes) {
+    source.addEventListener(kind, (message) => {
+      try {
+        const parsed = JSON.parse((message as MessageEvent).data) as AiCloudEvent
+        if (parsed.specversion === '1.0' && parsed.id && parsed.type === kind) onEvent(parsed)
       } catch { /* keep stream alive */ }
     })
   }

--- a/webui/src/api.ts
+++ b/webui/src/api.ts
@@ -1,5 +1,5 @@
 import { aiResultEventTypes } from './aiResults'
-import type { AiCloudEvent, AiModelInfo, AiOsdMode, AiProjectDocument, AiProjectSummary, AiStatus, DaemonStatus, LogEntry, PersistentState, RecordingList, RecordingSettings, RecordingStatus, RtspStatus, ServerEvent, WorkerConfig } from './types'
+import type { AboutInfo, AiCloudEvent, AiModelInfo, AiOsdMode, AiProjectDocument, AiProjectSummary, AiStatus, DaemonStatus, LogEntry, PersistentState, RecordingList, RecordingSettings, RecordingStatus, RtspStatus, ServerEvent, WorkerConfig } from './types'
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const response = await fetch(path, init)
@@ -9,6 +9,7 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 export const api = {
+  about: () => request<AboutInfo>('/api/v1/about'),
   status: () => request<DaemonStatus>('/api/v1/status'),
   config: () => request<PersistentState>('/api/v1/config'),
   logs: (limit = 100) => request<LogEntry[]>(`/api/v1/logs?limit=${limit}`),

--- a/webui/src/style.css
+++ b/webui/src/style.css
@@ -204,6 +204,39 @@ pre { overflow: auto; max-height: 280px; margin: 0; padding: 11px; background: #
 .model-header { border-top: 0; background: #f5f9f7; color: var(--muted); font: 9px ui-monospace, monospace; text-transform: uppercase; }
 .ai-models { overflow-x: auto; margin-bottom: 14px; }
 
+.about-page { max-width: 1180px; }
+.about-hero { display: grid; grid-template-columns: minmax(0, 1fr) 190px; align-items: center; gap: 34px; margin-bottom: 14px; background: linear-gradient(135deg, #f8fbfa 0%, #edf8f4 100%); }
+.about-hero h3 { margin: 7px 0 10px; font-size: 24px; letter-spacing: -.03em; }
+.about-hero p { max-width: 760px; margin: 0; color: #60776f; font-size: 12px; line-height: 1.8; }
+.about-badge { display: grid; place-items: center; min-height: 142px; border: 1px solid #cce4db; border-radius: 10px; background: #10201a; color: #d6f6e9; box-shadow: 0 16px 35px rgba(23, 64, 49, .12); }
+.about-badge span { color: #72d0ad; font: 10px ui-monospace, monospace; letter-spacing: .18em; }
+.about-badge strong { font: 25px ui-monospace, monospace; }
+.about-badge small { color: #9fbbb0; font-size: 9px; }
+.about-grid { display: grid; grid-template-columns: .8fr 1.2fr; gap: 14px; margin-bottom: 14px; }
+.about-platform dl { overflow: hidden; margin: 0; border: 1px solid var(--line); border-radius: 7px; }
+.about-platform dl div { display: grid; grid-template-columns: 90px minmax(0, 1fr); border-top: 1px solid var(--line); }
+.about-platform dl div:first-child { border-top: 0; }
+.about-platform dt, .about-platform dd { margin: 0; padding: 10px 12px; font: 10px ui-monospace, monospace; }
+.about-platform dt { background: #f3f8f6; color: var(--muted); text-transform: uppercase; }
+.about-platform dd { overflow: hidden; color: #3e5a50; text-overflow: ellipsis; white-space: nowrap; }
+.process-flow { display: grid; grid-template-columns: 1fr auto 1fr auto 1fr; align-items: stretch; gap: 8px; }
+.process-flow div { min-width: 0; padding: 14px 12px; border: 1px solid var(--line); border-radius: 7px; background: #f8fbfa; }
+.process-flow b, .process-flow span { display: block; }
+.process-flow b { color: #287d5e; font: 10px ui-monospace, monospace; }
+.process-flow span { margin-top: 7px; color: var(--muted); font-size: 9px; line-height: 1.5; }
+.process-flow i { align-self: center; color: #8ab8a7; font-style: normal; }
+.about-capabilities { margin-bottom: 14px; }
+.capability-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 9px; }
+.capability-grid div { padding: 14px; border: 1px solid var(--line); border-radius: 7px; background: #f8fbfa; }
+.capability-grid b { color: #35564a; font-size: 11px; }
+.capability-grid p { margin: 7px 0 0; color: var(--muted); font-size: 10px; line-height: 1.6; }
+.link-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
+.link-grid a { display: grid; grid-template-columns: 1fr auto; gap: 5px 12px; padding: 14px; border: 1px solid var(--line); border-radius: 7px; background: #f8fbfa; color: #287d5e; text-decoration: none; transition: border-color .15s, background .15s; }
+.link-grid a:hover { border-color: var(--mint); background: #edf8f4; }
+.link-grid span { font-size: 11px; font-weight: 700; }
+.link-grid b { font-size: 12px; }
+.link-grid small { grid-column: 1 / -1; color: var(--muted); font-size: 9px; }
+
 .recordings-page { max-width: 1220px; }
 .recording-control { margin-bottom: 14px; }
 .recording-state { padding: 6px 10px; border-radius: 99px; background: #edf3f1; color: var(--muted); font: 10px ui-monospace, monospace; text-transform: uppercase; }
@@ -272,6 +305,8 @@ pre { overflow: auto; max-height: 280px; margin: 0; padding: 11px; background: #
   .metric-column { grid-template-columns: 1fr 1fr; grid-template-rows: auto; }
   .diagnostic-grid { grid-template-columns: 1fr; }
   .ai-workspace { grid-template-columns: 1fr; }
+  .about-grid { grid-template-columns: 1fr; }
+  .capability-grid { grid-template-columns: 1fr 1fr; }
   .ai-result-row summary { grid-template-columns: 70px 90px minmax(130px, .8fr) minmax(220px, 1.5fr) 100px; min-width: 760px; }
   .log-lines, .event-lines { height: 520px; min-height: 0; }
 }
@@ -291,6 +326,10 @@ pre { overflow: auto; max-height: 280px; margin: 0; padding: 11px; background: #
   .hero-stats { grid-template-columns: 1fr 1fr; }
   .metric-column, .form-grid, .advanced { grid-template-columns: 1fr 1fr; }
   .ai-status-grid { grid-template-columns: 1fr 1fr; }
+  .about-hero { grid-template-columns: 1fr; }
+  .about-badge { min-height: 110px; }
+  .process-flow { grid-template-columns: 1fr; }
+  .process-flow i { justify-self: center; transform: rotate(90deg); }
   .result-bus-grid { grid-template-columns: 1fr 1fr; }
   .result-toolbar { flex-wrap: wrap; }
   .result-toolbar a { margin-left: 0; }
@@ -310,6 +349,7 @@ pre { overflow: auto; max-height: 280px; margin: 0; padding: 11px; background: #
   .controls { flex-wrap: wrap; }
   .preview-stats, .mini { grid-template-columns: 1fr 1fr; }
   .metric-column, .form-grid, .advanced, .config-stack { grid-template-columns: 1fr; }
+  .capability-grid, .link-grid { grid-template-columns: 1fr; }
   .advanced .wide { grid-column: auto; }
   .section-actions { width: 100%; }
   .section-actions button { flex: 1; }

--- a/webui/src/style.css
+++ b/webui/src/style.css
@@ -151,6 +151,40 @@ pre { overflow: auto; max-height: 280px; margin: 0; padding: 11px; background: #
 .ai-status-grid b { display: block; overflow: hidden; margin-top: 5px; font: 11px ui-monospace, monospace; text-overflow: ellipsis; white-space: nowrap; }
 .osd-modes { display: flex; align-items: center; gap: 7px; margin-top: 14px; color: var(--muted); font-size: 10px; }
 .osd-modes span { margin-right: 6px; }
+.ai-results-panel { margin-bottom: 14px; }
+.result-actions { align-items: center; }
+.result-connection { display: inline-flex; align-items: center; gap: 6px; padding: 6px 9px; border-radius: 99px; background: #f3f6f5; color: var(--muted); font: 9px ui-monospace, monospace; }
+.result-connection i { width: 6px; height: 6px; border-radius: 50%; background: var(--amber); }
+.result-connection.online { background: #eaf7f2; color: #287d5e; }
+.result-connection.online i { background: var(--mint); box-shadow: 0 0 0 3px rgba(36, 168, 120, .12); }
+.result-bus-grid { display: grid; grid-template-columns: 1.2fr 1.4fr repeat(3, 1fr); gap: 1px; overflow: hidden; border: 1px solid var(--line); border-radius: 7px; background: var(--line); }
+.result-bus-grid div { min-width: 0; padding: 10px 12px; background: #f8fbfa; }
+.result-bus-grid span { display: block; color: var(--muted); font: 8px ui-monospace, monospace; text-transform: uppercase; }
+.result-bus-grid b { display: block; overflow: hidden; margin-top: 4px; font: 10px ui-monospace, monospace; text-overflow: ellipsis; white-space: nowrap; }
+.result-toolbar { display: flex; align-items: flex-end; gap: 14px; margin: 12px 0 8px; color: var(--muted); font: 9px ui-monospace, monospace; }
+.result-toolbar label { display: flex; align-items: center; gap: 7px; }
+.result-toolbar select { width: 150px; margin: 0; padding: 6px 8px; font-size: 10px; }
+.result-toolbar a { margin-left: auto; color: #287d5e; text-decoration: none; }
+.result-toolbar a:hover { text-decoration: underline; }
+.ai-result-events { height: 410px; overflow: auto; overscroll-behavior: contain; border: 1px solid var(--line); border-radius: 7px; background: #f8fbfa; scrollbar-gutter: stable; }
+.ai-result-row { display: block; margin: 0; border-top: 1px solid #e2ece8; }
+.ai-result-row:first-child { border-top: 0; }
+.ai-result-row summary { display: grid; grid-template-columns: 72px 92px minmax(150px, .8fr) minmax(240px, 1.7fr) 105px; align-items: center; gap: 9px; padding: 10px 12px; list-style: none; cursor: pointer; font: 9px ui-monospace, monospace; }
+.ai-result-row summary::-webkit-details-marker { display: none; }
+.ai-result-row summary::before { display: none; }
+.ai-result-row time { color: #91a59e; }
+.ai-result-row b, .ai-result-row code, .result-summary { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ai-result-row b { color: #4b665d; font-weight: 500; }
+.ai-result-row code { color: #91a59e; text-align: right; }
+.result-type { justify-self: start; padding: 4px 6px; border-radius: 4px; background: #e9f5f0; color: #287d5e; font-weight: 700; }
+.result-summary { color: #71877f; }
+.ai-result-row pre { max-height: 330px; margin: 0 12px 12px; border-left: 2px solid #73c4a5; background: #edf5f2; }
+.result-tracks .result-type { background: #eef1fb; color: #596ca8; }
+.result-tracks pre { border-left-color: #8595c6; }
+.result-generation .result-type { background: #fff5e5; color: #a97626; }
+.result-generation pre, .result-gap pre { border-left-color: #d9a34e; }
+.result-gap .result-type, .result-exited .result-type { background: #fff0ee; color: var(--red); }
+.result-gap pre, .result-exited pre { border-left-color: #dc7b72; }
 .ai-workspace { display: grid; grid-template-columns: 245px minmax(0, 1fr); gap: 14px; margin-bottom: 14px; }
 .ai-project-list { align-self: start; }
 .project-item { display: block; position: relative; width: 100%; margin-top: 7px; padding: 12px; border-color: var(--line); background: #f8fbfa; text-align: left; }
@@ -168,7 +202,7 @@ pre { overflow: auto; max-height: 280px; margin: 0; padding: 11px; background: #
 .model-row { display: grid; grid-template-columns: minmax(160px, 1.2fr) 90px minmax(220px, 2fr) 85px 60px; align-items: center; gap: 8px; min-width: 760px; padding: 10px; border-top: 1px solid var(--line); color: #536a62; font-size: 10px; }
 .model-row code { overflow: hidden; color: var(--muted); font: 9px ui-monospace, monospace; text-overflow: ellipsis; }
 .model-header { border-top: 0; background: #f5f9f7; color: var(--muted); font: 9px ui-monospace, monospace; text-transform: uppercase; }
-.ai-models { overflow-x: auto; }
+.ai-models { overflow-x: auto; margin-bottom: 14px; }
 
 .recordings-page { max-width: 1220px; }
 .recording-control { margin-bottom: 14px; }
@@ -238,6 +272,7 @@ pre { overflow: auto; max-height: 280px; margin: 0; padding: 11px; background: #
   .metric-column { grid-template-columns: 1fr 1fr; grid-template-rows: auto; }
   .diagnostic-grid { grid-template-columns: 1fr; }
   .ai-workspace { grid-template-columns: 1fr; }
+  .ai-result-row summary { grid-template-columns: 70px 90px minmax(130px, .8fr) minmax(220px, 1.5fr) 100px; min-width: 760px; }
   .log-lines, .event-lines { height: 520px; min-height: 0; }
 }
 
@@ -256,6 +291,9 @@ pre { overflow: auto; max-height: 280px; margin: 0; padding: 11px; background: #
   .hero-stats { grid-template-columns: 1fr 1fr; }
   .metric-column, .form-grid, .advanced { grid-template-columns: 1fr 1fr; }
   .ai-status-grid { grid-template-columns: 1fr 1fr; }
+  .result-bus-grid { grid-template-columns: 1fr 1fr; }
+  .result-toolbar { flex-wrap: wrap; }
+  .result-toolbar a { margin-left: 0; }
   .config-stack { grid-template-columns: 1fr 1fr; }
   .section-head { flex-direction: column; }
   .event-head { align-items: flex-start; }

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -153,6 +153,19 @@ export interface RecordingEntry {
 export interface RecordingList { items: RecordingEntry[]; total: number; offset: number; limit: number }
 export interface RtspStatus { enabled: boolean; listening: boolean; bind: string; path: string; clients: number; max_clients: number; last_error: string | null }
 
+export interface AboutInfo {
+  project_name: string
+  console_name: string
+  platform_name: string
+  board_name: string
+  project_url: string
+  documentation_url: string
+  visiong_url: string
+  license_name: string
+  license_url: string
+  daemon_version: string
+}
+
 export type AiOsdMode = 'off' | 'metadata' | 'embedded_rgn'
 export interface AiProjectManifest {
   id: string

--- a/webui/src/types.ts
+++ b/webui/src/types.ts
@@ -211,6 +211,15 @@ export interface AiStatus {
   last_error: string | null
   osd_mode: AiOsdMode
   rgn_capability: { line: boolean; cover: boolean; backend: string; max_boxes: number; implemented: boolean } | null
+  result_bus: {
+    stream_id: string
+    latest_event_id: string | null
+    earliest_replay_event_id: string | null
+    published: number
+    replay_depth: number
+    replay_capacity: number
+    lagged_events: number
+  }
 }
 export interface AiDetection {
   track_id: number
@@ -231,4 +240,93 @@ export interface AiMetadata {
   main_height: number
   inference_us: number
   detections: AiDetection[]
+}
+
+export type AiResultEventType =
+  | 'io.aipc.ai.frame.v1'
+  | 'io.aipc.ai.track.entered.v1'
+  | 'io.aipc.ai.track.updated.v1'
+  | 'io.aipc.ai.track.exited.v1'
+  | 'io.aipc.ai.stream.gap.v1'
+  | 'io.aipc.ai.generation.v1'
+
+export interface AiResultBoundingBox {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface AiResultObject {
+  track_id: number
+  class_id: number
+  label: string
+  confidence: number
+  bbox: AiResultBoundingBox
+}
+
+export interface AiResultFrameInfo {
+  width: number
+  height: number
+  coordinate_space: 'main_normalized_top_left'
+}
+
+export interface AiResultInferenceInfo {
+  project: string
+  algorithm: string
+  model: string
+  duration_us: number
+}
+
+export interface AiFrameResultData {
+  schema_version: 1
+  source_id: string
+  media_generation: string
+  ai_generation: string
+  sequence: number
+  pts_us: number
+  published_at_ms: number
+  frame: AiResultFrameInfo
+  inference: AiResultInferenceInfo
+  objects: AiResultObject[]
+}
+
+export interface AiTrackResultData extends Omit<AiFrameResultData, 'objects'> {
+  object: AiResultObject
+  reason: string
+}
+
+export interface AiGenerationResultData {
+  schema_version: 1
+  source_id: string
+  media_generation: string | null
+  ai_generation: string | null
+  previous_media_generation: string | null
+  previous_ai_generation: string | null
+  state: 'started' | 'stopped'
+  reason: string
+  published_at_ms: number
+}
+
+export interface AiStreamGapResultData {
+  schema_version: 1
+  source_id: string
+  requested_event_id: string | null
+  earliest_event_id: string | null
+  latest_event_id: string | null
+  reason: string
+}
+
+export type AiCloudEventData = AiFrameResultData | AiTrackResultData | AiGenerationResultData | AiStreamGapResultData
+
+export interface AiCloudEvent {
+  specversion: '1.0'
+  id: string
+  source: string
+  type: AiResultEventType
+  subject: string
+  time: string
+  datacontenttype: 'application/json'
+  dataschema: string
+  data: AiCloudEventData
 }


### PR DESCRIPTION
## Summary
- add a canonical CloudEvents 1.0 AI result bus with latest, SSE replay, lifecycle and schema endpoints
- add a bounded real-time standard AI event viewer at the bottom of the AI/Lua page
- add an About page and move platform/board branding and project links into daemon configuration

## Validation
- cargo test --workspace (41 passed, 1 ignored live-board test)
- npm --prefix webui test (18 passed)
- npm --prefix webui run build
- cargo fmt --all -- --check
- git diff --check
- RV1106 standardized event API and viewer previously validated with live YOLOv5 output